### PR TITLE
feat(pricing-advisory): market order pricing advisory improvements

### DIFF
--- a/docs/market_order_pricing_advisory.txt
+++ b/docs/market_order_pricing_advisory.txt
@@ -1,0 +1,326 @@
+================================================================================
+  MARKET ORDER PRICING ADVISORY — HOW ADVISED PRICES AND CONFIDENCE ARE COMPUTED
+================================================================================
+
+The Market Orders page shows an "Advised Price", "Advice Confidence", estimated
+sell days, and ISK/day for each sell order. This document explains where those
+values come from, how they are calculated, and what they mean.
+
+
+────────────────────────────────────────────────────────────────────────────────
+  OVERVIEW
+────────────────────────────────────────────────────────────────────────────────
+
+The advised price is a weighted average of up to five independent inputs
+("components"). Components that cannot be computed for a given item are silently
+excluded, and the remaining weights are renormalised so they still sum to 100%.
+
+Confidence is assessed separately from the price calculation. It measures how
+much data was available, not whether the resulting price is a good idea.
+
+All values are computed by PricingSuggestionService (see
+src/eve_online_industry_tracker/application/market_analysis/
+pricing_suggestion_service.py) and returned by the Flask endpoint:
+
+    GET /characters/market_orders?refresh=0|1&compare=0|1
+
+The Streamlit UI surfaces these values in two places:
+  - Sell-orders grid: "Advised Price", "Advice Confidence", "Est. Days (Adv.)",
+    "ISK/day (Adv.)" columns
+  - Pricing Analysis panel (bottom of page): full breakdown per selected order
+
+
+────────────────────────────────────────────────────────────────────────────────
+  THE FIVE PRICE COMPONENTS
+────────────────────────────────────────────────────────────────────────────────
+
+Component 0 — Your Cost Basis  (15% weight)
+────────────────────────────────────────────
+  Source: CharacterAssetsModel.acquisition_unit_cost for the character + type_id.
+  If multiple asset rows exist, a quantity-weighted average is computed.
+
+  A 5% margin is added on top of cost before this value enters the weighted
+  average (cost_with_margin = acquisition_unit_cost × 1.05).
+
+  This component also acts as a hard floor. After the weighted average is
+  computed, if the result falls below cost × 1.05, it is clamped upward.
+
+  Fallback: if no assets exist or none have cost data, the component falls back
+  to the current market order price. This fallback is labelled
+  "market_order_fallback" in the UI and triggers a warning banner, because it
+  means the asset is missing from the tracked inventory (ESI data lag).
+
+  acquisition_source values:
+    "manufactured"          → item was built; cost = unit_build_cost from job
+    "bought"                → item was purchased on the market
+    "market_order_fallback" → no asset record found; order price used as proxy
+
+Component 1 — Your Recent Sales  (20% weight)
+──────────────────────────────────────────────
+  Source: SalesHistoryService.suggest_sell_price() — median of recent wallet
+  sell transactions for the same type_id.
+
+  Carries its own sub-confidence ("high", "medium", "low", "none") based on
+  sample size, which feeds into the overall confidence score (see below).
+
+Component 2 — Current Market Hub Price  (35% weight)
+─────────────────────────────────────────────────────
+  Source: market_pricing_service.get_type_price_map(side="sell", hub="jita") —
+  the current lowest sell order(s) at Jita 4-4 (region 10000002).
+
+  Highest-weight component. If unavailable (pricing cache not populated), its
+  35% weight is redistributed proportionally across the other components.
+
+Component 3 — Market Trend  (15% weight)
+─────────────────────────────────────────
+  Source: MarketHistoryService.get_price_stats() — Jita daily OHLC from
+  MarketHistoryModel.
+
+      adjustment_factor = 1.0 + (trend_pct / 100 × 0.5)
+      market_trend_price = avg_42w × adjustment_factor
+
+  where trend_pct = ((avg_7d - avg_42w) / avg_42w) × 100.
+
+  A rising market nudges the advised price up by half the observed trend rate;
+  a falling market nudges it down.
+
+Component 4 — Liquidity Adjustment  (15% weight)
+──────────────────────────────────────────────────
+  Source: MarketHistoryService.get_volume_stats() — average daily traded volume.
+
+      avg_daily_volume < 100     → current_price × 0.95  (thin market)
+      avg_daily_volume > 10,000  → current_price × 1.02  (high liquidity)
+      otherwise                  → current_price (neutral)
+
+
+────────────────────────────────────────────────────────────────────────────────
+  WEIGHT REDISTRIBUTION
+────────────────────────────────────────────────────────────────────────────────
+
+The nominal weights sum to 1.0. When one or more components are absent, the
+weighted price divides by the sum of weights that ARE present, so remaining
+components each gain proportionally more influence.
+
+If no components are available, the advised price equals the current order price.
+
+
+────────────────────────────────────────────────────────────────────────────────
+  CONFIDENCE SCORING
+────────────────────────────────────────────────────────────────────────────────
+
+Confidence is an additive score from 0 to 10. Final band:
+
+    score ≥ 8  →  "high"
+    score ≥ 4  →  "medium"
+    score < 4  →  "low"
+
+The four signals and their point contributions:
+
+  1. Cost basis availability               +2 if cost_basis > 0
+
+  2. Sales history confidence
+       "high"    →  +3
+       "medium"  →  +2
+       "low"     →  +1
+       "none"    →  +0
+
+  3. Market data completeness (record_count from MarketHistoryService)
+       > 100 records  →  +3
+       > 30 records   →  +2
+       > 7 records    →  +1
+       ≤ 7 records    →  +0
+
+  4. Volume data                           +2 if avg_daily_volume > 100
+
+Maximum reachable score is 10 (2 + 3 + 3 + 2 = 10).
+
+
+────────────────────────────────────────────────────────────────────────────────
+  PROFITABILITY METRICS (after fees)
+────────────────────────────────────────────────────────────────────────────────
+
+These metrics are computed for both the advised price and the current order price
+to help decide whether to relist.
+
+  Fee inputs
+    sales_tax_fraction   — read from CharacterModel.market_fees (set by
+                           refresh_market_fees(): base 7.5%, reduced by
+                           Accounting skill level at 11% per level).
+    broker_fee_fraction  — read from CharacterModel.market_fees (base varies by
+                           Broker Relations skill and station standings, capped
+                           at 3%).
+    Defaults if unavailable: 7.5% tax, 3% broker fee.
+
+  Break-even price
+    The minimum list price to recover cost after fees:
+        break_even = cost_basis / (1 - sales_tax_fraction - broker_fee_fraction)
+    Items listed below this price result in a net loss.
+
+  Net margin %
+        net_proceeds = price × (1 - sales_tax - broker_fee)
+        net_margin   = (net_proceeds - cost_basis) / price × 100
+    Shown for both advised and current price.
+
+  ISK/day
+        profit_per_unit = price × (1 - sales_tax - broker_fee) - cost_basis
+        isk_per_day     = profit_per_unit × quantity / estimated_sell_days
+    The primary decision metric: combines margin and sell velocity.
+    A slightly lower price that sells 3× faster typically yields much better
+    ISK/day than a higher price that sits on the market.
+
+
+────────────────────────────────────────────────────────────────────────────────
+  ESTIMATED SELL DAYS
+────────────────────────────────────────────────────────────────────────────────
+
+Computed for both the advised price and the current order price.
+
+Data sources:
+  - MarketOrderbookViewCacheModel / market_orderbook_cache_repo:
+    cached Jita 4-4 sell orderbook levels [[price, volume], ...].
+  - MarketHistoryModel avg_daily_volume: total market daily volume for the item.
+
+Formula (two stages):
+
+  Stage A — days until our order is effectively at the front of the queue:
+      volume_ahead = sum of volumes from sell orders priced < target_price
+      days_until_front = volume_ahead / avg_daily_volume
+
+  Stage B — days for our own units to sell once at the front:
+      volume_at_level = competing volume listed at ≈ our price level
+      capture_rate    = quantity / (quantity + volume_at_level),
+                        clamped to [5%, 50%]  (we will not capture all daily volume)
+      days_for_our_units = quantity / (avg_daily_volume × capture_rate)
+
+  total_estimated_days = days_until_front + days_for_our_units
+
+Caveats:
+  - The orderbook cache stores only the top N levels (configurable, default 5).
+    If our price sits above those levels, volume_ahead is underestimated and the
+    sell date is optimistic (treat it as a lower bound).
+  - If the orderbook cache is empty (not yet populated for this item), the
+    queue is assumed to be empty and we capture up to 35% of daily volume.
+  - The estimate is for trading days of market activity, not calendar days.
+
+The "Est. Days (Adv.)" column in the sell-orders grid shows the estimate for
+the advised price. The full panel shows both estimates side by side.
+
+
+────────────────────────────────────────────────────────────────────────────────
+  HOLD SIGNAL
+────────────────────────────────────────────────────────────────────────────────
+
+When the market trend is rising significantly (trend_pct > 5%), the system
+computes whether waiting 7 days would yield more total ISK than selling now.
+
+  daily_rate    = trend_pct / (42 × 7)   (daily drift implied by 42w baseline)
+  price_in_7d   = hub_price × (1 + daily_rate × 7)
+  gain_per_unit = price_in_7d - hub_price
+  total_gain    = gain_per_unit × quantity
+
+  opportunity_cost_7d = isk_per_day_advised × 7   (what you'd earn by selling now)
+
+  Hold suggested if: total_gain > opportunity_cost_7d AND total_gain > 0
+
+The hold signal is shown as an info banner in the Pricing Analysis panel. It is
+a heuristic — the linear extrapolation does not account for volatility, large
+buy/sell walls, or game events that can move prices discontinuously.
+
+
+────────────────────────────────────────────────────────────────────────────────
+  RELIST RISK
+────────────────────────────────────────────────────────────────────────────────
+
+If estimated_sell_days_advised > order_duration_days (from the ESI order's
+"duration" field, typically 90 days), the order is flagged as at risk of
+expiring before selling.
+
+  unsold_fraction        = 1 - (order_duration_days / estimated_sell_days)
+  estimated_unsold_qty   = quantity × unsold_fraction
+  estimated_relist_cost  = price × broker_fee_fraction × estimated_unsold_qty
+
+The relist cost is an approximation: it assumes you relist at the same price and
+do not receive a partial broker credit (EVE does grant a partial credit but the
+exact amount depends on how much of the order filled before expiry).
+
+A warning banner is shown in the Pricing Analysis panel when at_risk = True.
+
+
+────────────────────────────────────────────────────────────────────────────────
+  HUMAN-READABLE REASONING STRING
+────────────────────────────────────────────────────────────────────────────────
+
+The "reasoning" caption lists which components contributed and the confidence
+band. For example:
+
+    "Based on: Your cost basis (floor), Your recent sales (12 samples),
+     Current market hub price, Market rising (+3.2%). Confidence: high."
+
+
+────────────────────────────────────────────────────────────────────────────────
+  UI SURFACE — WHERE THE ADVISORY APPEARS
+────────────────────────────────────────────────────────────────────────────────
+
+Sell Orders grid  (marketorders.py:_build_order_rows)
+  "Advised Price"       — advised_price in ISK
+  "Advice Confidence"   — "high", "medium", or "low"
+  "Est. Days (Adv.)"    — estimated_sell_days_advised, rounded to 1 decimal
+  "ISK/day (Adv.)"      — isk_per_day_advised in ISK
+
+  These columns are only added when the API returns a non-null advised_price.
+  Buy orders do not receive advised pricing.
+
+Pricing Analysis panel  (marketorders.py:_render_pricing_analysis)
+  Row 1: Current Price / Advised Price / Difference | Confidence + reasoning |
+          Your Cost / Break-even Price
+  Row 2: Net Margin % (advised vs current) | Est. Days (advised vs current) |
+          ISK/day (advised vs current)
+  Hold signal banner (info)  — when trend favours holding
+  Relist risk banner (warning) — when est. sell days > order duration
+  Pricing Components list    — one line per present component with weight
+
+
+────────────────────────────────────────────────────────────────────────────────
+  RELATIONSHIP TO INDUSTRY BUILDER CONFIDENCE
+────────────────────────────────────────────────────────────────────────────────
+
+The market order advisory confidence (this document) is SEPARATE from the
+Industry Builder's pricing confidence (documented in cost_allocation.txt,
+Phase 6).
+
+  Industry Builder confidence measures how reliably the input material costs
+  and the market sell price for the product are known, combining market_sell
+  confidence (orderbook depth, anomaly risk) with material_pricing confidence
+  (FIFO coverage, unknown cost basis flags).
+
+  Market order advisory confidence measures how much supporting data exists to
+  suggest an optimal re-listing price for inventory you already hold: your own
+  cost basis, your own sales history, market history depth, and volume.
+
+The two scores use different inputs, different scales, and serve different
+screens. They are not derived from each other.
+
+
+────────────────────────────────────────────────────────────────────────────────
+  FUTURE IMPROVEMENTS (not yet implemented)
+────────────────────────────────────────────────────────────────────────────────
+
+  ML-based price forecasting (7/14/30 day):
+    MarketHistoryModel has daily OHLC + volume going back years — a ready-made
+    time series per item. Prophet (Facebook/Meta) or statsmodels ARIMA could
+    produce a price forecast with a confidence interval, improving the trend
+    component and the hold signal.
+
+  ML sell-velocity prediction:
+    A regression model trained on (price, market conditions) → days_to_sell
+    would replace the orderbook queue heuristic. Requires "listing date" to be
+    recorded when an order first appears in ESI (add first_seen_at to the market
+    orders model). After 4–8 weeks of labelled data, a scikit-learn gradient
+    boosted regressor is a practical fit.
+
+  Both ML paths require EVE-specific guards:
+    - Median/IQR-based feature engineering to suppress manipulation spikes
+    - Minimum daily volume threshold (< ~20/day → fall back to heuristic)
+    - Prophet changepoint detection for patch-driven step changes
+
+================================================================================

--- a/docs/market_order_pricing_advisory.txt
+++ b/docs/market_order_pricing_advisory.txt
@@ -63,13 +63,22 @@ Component 1 — Your Recent Sales  (20% weight)
   Carries its own sub-confidence ("high", "medium", "low", "none") based on
   sample size, which feeds into the overall confidence score (see below).
 
-Component 2 — Current Market Hub Price  (35% weight)
-─────────────────────────────────────────────────────
+Component 2 — Current Market Hub Price  (up to 35% weight, volatility-dampened)
+─────────────────────────────────────────────────────────────────────────────────
   Source: market_pricing_service.get_type_price_map(side="sell", hub="jita") —
   the current lowest sell order(s) at Jita 4-4 (region 10000002).
 
-  Highest-weight component. If unavailable (pricing cache not populated), its
-  35% weight is redistributed proportionally across the other components.
+  [B] Volatility-dampened weight:
+    The raw 35% weight is reduced when the market has been volatile:
+
+        hub_weight = max(0.15, 0.35 / (1 + volatility_pct / 100))
+
+    Examples:
+      volatility = 0%   → hub_weight = 35%  (calm, trust the snapshot)
+      volatility = 50%  → hub_weight = 23%  (moderate dampening)
+      volatility = 100% → hub_weight = 17%  (high noise, minimum weight)
+
+    The released weight is redistributed proportionally to other components.
 
 Component 3 — Market Trend  (15% weight)
 ─────────────────────────────────────────
@@ -84,13 +93,35 @@ Component 3 — Market Trend  (15% weight)
   A rising market nudges the advised price up by half the observed trend rate;
   a falling market nudges it down.
 
-Component 4 — Liquidity Adjustment  (15% weight)
-──────────────────────────────────────────────────
-  Source: MarketHistoryService.get_volume_stats() — average daily traded volume.
+Component 4 — Supply/Demand Signal  (15% weight)           [replaces Liquidity]
+────────────────────────────────────────────────────────────────────────────────
+  [A] Source: orderbook queue depth + avg_daily_volume.
 
-      avg_daily_volume < 100     → current_price × 0.95  (thin market)
-      avg_daily_volume > 10,000  → current_price × 1.02  (high liquidity)
-      otherwise                  → current_price (neutral)
+      days_of_supply = total_sell_volume_in_orderbook / avg_daily_volume
+
+  Three buckets:
+    > 30 days supply → oversupplied  → signal_price = hub_price × 0.97
+    7–30 days supply → balanced      → signal_price = hub_price
+    < 7 days supply  → undersupplied → signal_price = hub_price × 1.03
+
+  This replaces the old three-bucket liquidity adjustment that used raw
+  daily volume thresholds (100/10,000). The new signal reflects how many
+  days' worth of competing sell orders currently exist, which is a more
+  direct measure of supply pressure.
+
+Component 5 — Buy-Sell Spread Signal  (10% weight)              [new component]
+────────────────────────────────────────────────────────────────────────────────
+  [C] Source: hub sell price (side="sell") vs hub buy price (side="buy").
+
+      spread_pct = (hub_sell_price - hub_buy_price) / hub_sell_price × 100
+
+  Three buckets:
+    < 5%  → tight spread  → demand strong → signal_price = hub_sell × 1.01
+    5–25% → normal spread → signal_price = hub_sell
+    > 25% → wide spread   → thin demand   → signal_price = midpoint(sell, buy)
+
+  A tight spread signals buy-side pressure pushing toward the ask; a wide
+  spread signals illiquid demand and warrants more conservative pricing.
 
 
 ────────────────────────────────────────────────────────────────────────────────
@@ -151,10 +182,18 @@ to help decide whether to relist.
                            at 3%).
     Defaults if unavailable: 7.5% tax, 3% broker fee.
 
-  Break-even price
+  Break-even price (hard floor 1)
     The minimum list price to recover cost after fees:
         break_even = cost_basis / (1 - sales_tax_fraction - broker_fee_fraction)
     Items listed below this price result in a net loss.
+    The advised price is always clamped upward to this floor.
+
+  Minimum target margin price (hard floor 2)             [E — configurable]
+    A second, higher floor based on your configured profit target:
+        min_target_price = cost_basis / (1 - min_margin - sales_tax - broker_fee)
+    Default min_margin = 8 % (configurable in cfg_manager under
+    defaults.market_advisory.min_target_margin_pct).
+    The advised price is clamped to the higher of the two floors.
 
   Net margin %
         net_proceeds = price × (1 - sales_tax - broker_fee)
@@ -247,6 +286,36 @@ A warning banner is shown in the Pricing Analysis panel when at_risk = True.
 
 
 ────────────────────────────────────────────────────────────────────────────────
+  PRICE BAND — THREE-TIER LISTING STRATEGY                [F — new feature]
+────────────────────────────────────────────────────────────────────────────────
+
+Rather than a single advised price the system now returns three price tiers that
+answer different strategic questions.
+
+  Tier 1 — Aggressive (fastest sell)
+    Goal: clear inventory as quickly as possible.
+    Method: undercut the cheapest competing sell order by 0.01 ISK.
+    Floor: never below the minimum target margin price (or break-even if
+           no margin config). If our current price is already at or below
+           the queue front, we do not go lower — aggressive = target.
+
+  Tier 2 — Target (optimal ISK/day)
+    The advised price as computed by the weighted average, after both floor
+    clamps. This is the main recommended price — it maximises expected
+    ISK-per-day across the estimated sell window.
+
+  Tier 3 — Premium (trend hold)
+    Goal: maximise total ISK if the market is rising.
+    Method: project the 42-week trend forward 14 days.
+        daily_rate    = trend_pct / (42 × 7)
+        price_premium = hub_price × (1 + daily_rate × 14)
+    Capped at hub_price × 1.25 to avoid absurd suggestions.
+    If trend_pct ≤ 2 %, premium = target (market not trending up).
+
+  Each tier shows estimated sell days, ISK/day, and net margin % so you can
+  compare the strategy implications side by side.
+
+────────────────────────────────────────────────────────────────────────────────
   HUMAN-READABLE REASONING STRING
 ────────────────────────────────────────────────────────────────────────────────
 
@@ -262,11 +331,20 @@ band. For example:
 ────────────────────────────────────────────────────────────────────────────────
 
 Sell Orders grid  (marketorders.py:_build_order_rows)
-  "Advised Price"       — advised_price in ISK
-  "Advice Confidence"   — "high", "medium", or "low"
-  "Est. Days (Adv.)"    — estimated_sell_days_advised, rounded to 1 decimal
-  "ISK/day (Adv.)"      — isk_per_day_advised in ISK
+  "Advised Price"         — advised_price in ISK
+  "Advice Confidence"     — "high", "medium", or "low"
+  "Est. Days (Adv.)"      — estimated_sell_days_advised, rounded to 1 decimal
+  "ISK/day (Adv.)"        — isk_per_day_advised in ISK
+  "Margin % (Current)"    — net margin at current list price (colour-coded)
+  "Margin % (Advised)"    — net margin at advised price (colour-coded)
 
+  Margin colour coding:
+    < 0 %     → red background (below break-even)
+    0–5 %     → amber (thin margin)
+    5–15 %    → neutral
+    ≥ 15 %    → green text (healthy margin)
+
+  A red error banner is shown if any order has Margin % (Current) < 0 %.
   These columns are only added when the API returns a non-null advised_price.
   Buy orders do not receive advised pricing.
 
@@ -275,9 +353,12 @@ Pricing Analysis panel  (marketorders.py:_render_pricing_analysis)
           Your Cost / Break-even Price
   Row 2: Net Margin % (advised vs current) | Est. Days (advised vs current) |
           ISK/day (advised vs current)
-  Hold signal banner (info)  — when trend favours holding
+  Hold signal banner (info)   — when trend favours holding
   Relist risk banner (warning) — when est. sell days > order duration
-  Pricing Components list    — one line per present component with weight
+  Pricing Components list     — one line per present component with weight and
+                                context (trend %, volatility dampening, spread %)
+  Price Band (F)              — three columns: Aggressive / Target / Premium,
+                                each showing price, est. days, ISK/day, margin
 
 
 ────────────────────────────────────────────────────────────────────────────────
@@ -299,6 +380,29 @@ Phase 6).
 
 The two scores use different inputs, different scales, and serve different
 screens. They are not derived from each other.
+
+
+────────────────────────────────────────────────────────────────────────────────
+  ALGORITHM IMPROVEMENT REFERENCE
+────────────────────────────────────────────────────────────────────────────────
+
+  The following improvements (A/B/C/E/F) were implemented on branch
+  feature/market-order-pricing-advisory-improvements.
+
+  A — Days-of-supply signal (replaces liquidity bucket)
+      Three-bucket supply pressure using orderbook volume ÷ avg daily volume.
+
+  B — Volatility-dampened hub weight
+      Hub price weight reduced dynamically when price history shows high noise.
+
+  C — Buy-sell spread signal (new 10% component)
+      Spread between Jita best-sell and best-buy as demand-pressure indicator.
+
+  E — Configurable minimum margin floor
+      Second price floor after break-even; default 8%, configurable in cfg.
+
+  F — Price band (aggressive / target / premium)
+      Three-tier listing strategy shown in Pricing Analysis panel.
 
 
 ────────────────────────────────────────────────────────────────────────────────

--- a/src/eve_online_industry_tracker/application/characters/service.py
+++ b/src/eve_online_industry_tracker/application/characters/service.py
@@ -188,6 +188,8 @@ class CharactersService:
                             character_id=character_id,
                             type_id=type_id,
                             current_price=order_price,
+                            quantity=int(order.get("volume_remain") or 0),
+                            order_duration_days=duration_days_int or 90,
                         )
                     except Exception:
                         advised_price_data = None
@@ -227,6 +229,17 @@ class CharactersService:
                     enriched_order["cost_basis"] = advised_price_data.get("cost_basis")
                     enriched_order["acquisition_source"] = advised_price_data.get("acquisition_source")
                     enriched_order["cost_basis_source"] = advised_price_data.get("cost_basis_source")
+                    enriched_order["price_difference_pct"] = advised_price_data.get("price_difference_pct")
+                    # Profitability metrics
+                    enriched_order["break_even_price"] = advised_price_data.get("break_even_price")
+                    enriched_order["net_margin_pct_advised"] = advised_price_data.get("net_margin_pct_advised")
+                    enriched_order["net_margin_pct_current"] = advised_price_data.get("net_margin_pct_current")
+                    enriched_order["estimated_sell_days_advised"] = advised_price_data.get("estimated_sell_days_advised")
+                    enriched_order["estimated_sell_days_current"] = advised_price_data.get("estimated_sell_days_current")
+                    enriched_order["isk_per_day_advised"] = advised_price_data.get("isk_per_day_advised")
+                    enriched_order["isk_per_day_current"] = advised_price_data.get("isk_per_day_current")
+                    enriched_order["hold_signal"] = advised_price_data.get("hold_signal")
+                    enriched_order["relist_risk"] = advised_price_data.get("relist_risk")
 
                 enriched_orders.append(enriched_order)
 

--- a/src/eve_online_industry_tracker/application/characters/service.py
+++ b/src/eve_online_industry_tracker/application/characters/service.py
@@ -183,6 +183,9 @@ class CharactersService:
                 advised_price_data = None
                 character_id = order.get("character_id") or (character or {}).get("character_id")
                 if not order.get("is_buy_order") and isinstance(type_id, int) and isinstance(character_id, int):
+                    days_remaining_int: int | None = None
+                    if expires_in_td.total_seconds() > 0:
+                        days_remaining_int = max(0, expires_in_td.days)
                     try:
                         advised_price_data = pricing_svc.suggest_price(
                             character_id=character_id,
@@ -190,6 +193,7 @@ class CharactersService:
                             current_price=order_price,
                             quantity=int(order.get("volume_remain") or 0),
                             order_duration_days=duration_days_int or 90,
+                            days_remaining=days_remaining_int,
                         )
                     except Exception:
                         advised_price_data = None
@@ -242,7 +246,40 @@ class CharactersService:
                     enriched_order["relist_risk"] = advised_price_data.get("relist_risk")
                     enriched_order["price_band"] = advised_price_data.get("price_band")
                     enriched_order["min_target_margin_pct"] = advised_price_data.get("min_target_margin_pct")
+                    enriched_order["fill_rate_velocity"] = advised_price_data.get("fill_rate_velocity")
+                    enriched_order["seller_concentration"] = advised_price_data.get("seller_concentration")
+                    enriched_order["expiry_urgency"] = advised_price_data.get("expiry_urgency")
+                    enriched_order["expiry_urgency_detail"] = advised_price_data.get("expiry_urgency_detail")
 
                 enriched_orders.append(enriched_order)
+
+        # Compute repricing priority score for sell orders
+        for order in enriched_orders:
+            if order.get("is_buy_order") or not order.get("advised_price"):
+                order["reprice_priority_score"] = 0.0
+                continue
+            score = 0.0
+            # Critical: losing money after fees
+            if (order.get("net_margin_pct_current") or 0) < 0:
+                score += 100.0
+            # ISK/day improvement opportunity
+            adv_day = order.get("isk_per_day_advised") or 0
+            cur_day = order.get("isk_per_day_current") or 0
+            if adv_day > cur_day and adv_day > 0:
+                daily_gain_m = (adv_day - cur_day) / 1_000_000
+                score += min(50.0, daily_gain_m * 5)
+            # Expiry urgency
+            if order.get("expiry_urgency"):
+                score += 40.0
+            # Relist risk
+            if (order.get("relist_risk") or {}).get("at_risk"):
+                score += 25.0
+            # Being undercut at current price
+            price = float(order.get("price") or 0)
+            advised = float(order.get("advised_price") or price)
+            if price > 0 and advised < price:
+                undercut_pct = (price - advised) / price * 100
+                score += min(20.0, undercut_pct * 2)
+            order["reprice_priority_score"] = round(score, 1)
 
         return enriched_orders

--- a/src/eve_online_industry_tracker/application/characters/service.py
+++ b/src/eve_online_industry_tracker/application/characters/service.py
@@ -240,6 +240,8 @@ class CharactersService:
                     enriched_order["isk_per_day_current"] = advised_price_data.get("isk_per_day_current")
                     enriched_order["hold_signal"] = advised_price_data.get("hold_signal")
                     enriched_order["relist_risk"] = advised_price_data.get("relist_risk")
+                    enriched_order["price_band"] = advised_price_data.get("price_band")
+                    enriched_order["min_target_margin_pct"] = advised_price_data.get("min_target_margin_pct")
 
                 enriched_orders.append(enriched_order)
 

--- a/src/eve_online_industry_tracker/application/market_analysis/pricing_suggestion_service.py
+++ b/src/eve_online_industry_tracker/application/market_analysis/pricing_suggestion_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import statistics
 from datetime import datetime
 from typing import Any
@@ -9,6 +10,7 @@ from typing import Any
 from sqlalchemy import and_
 from eve_online_industry_tracker.application.industry.sales_history_service import SalesHistoryService
 from eve_online_industry_tracker.application.market_analysis.market_history_service import MarketHistoryService
+from eve_online_industry_tracker.application.market_pricing import MarketPricingService
 from eve_online_industry_tracker.infrastructure.models import CharacterAssetsModel, CharacterAssetHistoryModel, CharacterModel
 from eve_online_industry_tracker.infrastructure.session_provider import SessionProvider, StateSessionProvider
 
@@ -21,6 +23,7 @@ class PricingSuggestionService:
         self._sessions = sessions or StateSessionProvider(state=state)
         self._sales_history = SalesHistoryService(state=state, sessions=sessions)
         self._market_history = MarketHistoryService(state=state, sessions=sessions)
+        self._market_pricing = MarketPricingService(state=state, sessions=self._sessions)
 
     def suggest_price(
         self,
@@ -88,6 +91,34 @@ class PricingSuggestionService:
             breakdown["floored_to_target_margin"] = True
             breakdown["min_target_margin_pct"] = round(min_target_margin * 100, 1)
 
+        # Snap to nearest valid EVE price tick (4 significant figures)
+        advised_price = self._snap_to_eve_tick(advised_price)
+        breakdown["weighted_price"] = advised_price
+
+        # Gap positioning: if being undercut, prefer the highest gap price over the
+        # weighted average — no reason to go lower than the nearest undercutter - 1 tick.
+        _gap_floor = min_target_price or break_even or advised_price
+        gap_price = self._find_gap_position(
+            current_price=current_price,
+            orderbook_levels=orderbook_levels,
+            floor_price=_gap_floor,
+        )
+        if gap_price is not None and gap_price > advised_price:
+            advised_price = gap_price
+            breakdown["weighted_price"] = advised_price
+            breakdown["gap_positioned"] = True
+            breakdown["gap_price"] = gap_price
+
+        # Front-of-queue guard: if already the cheapest seller, never advise going lower.
+        # Reducing price when front of queue only hurts margin — no one is buying from a
+        # cheaper competitor because there isn't one.
+        if orderbook_levels and current_price > 0:
+            front_price = orderbook_levels[0][0]
+            if current_price <= front_price and advised_price < current_price:
+                advised_price = self._snap_to_eve_tick(current_price)
+                breakdown["weighted_price"] = advised_price
+                breakdown["already_front_of_queue"] = True
+
         floor = min_target_price or break_even or advised_price
 
         net_margin_advised = self._calc_net_margin(price=advised_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
@@ -125,7 +156,9 @@ class PricingSuggestionService:
                 urgency_ratio = max(0.0, 1.0 - (days_remaining / max(1.0, est_days_advised * 0.5)))
                 blend = min(0.5, urgency_ratio)  # cap at 50% blend toward aggressive
                 aggressive_price = (price_band or {}).get("aggressive", {}).get("price") or advised_price
-                urgency_price = max(floor, advised_price * (1.0 - blend) + aggressive_price * blend)
+                urgency_price = self._snap_to_eve_tick(
+                    max(floor, advised_price * (1.0 - blend) + aggressive_price * blend)
+                )
                 expiry_urgency_detail = {
                     "days_remaining": int(days_remaining),
                     "est_days_advised": round(est_days_advised, 1),
@@ -178,10 +211,7 @@ class PricingSuggestionService:
 
     def _get_hub_price(self, *, type_id: int, hub: str = "jita") -> float | None:
         try:
-            svc = getattr(self._state, "market_pricing_service", None)
-            if svc is None:
-                return None
-            price_map = svc.get_type_price_map(type_ids=[type_id], hub=hub, side="sell")
+            price_map = self._market_pricing.get_type_price_map(type_ids=[type_id], hub=hub, side="sell")
             if type_id in price_map:
                 return float(price_map[type_id].get("unit_price") or 0) or None
         except Exception as exc:
@@ -191,10 +221,7 @@ class PricingSuggestionService:
     def _get_hub_buy_price(self, *, type_id: int, hub: str = "jita") -> float | None:
         """Best Jita buy order price — used to compute the buy-sell spread."""
         try:
-            svc = getattr(self._state, "market_pricing_service", None)
-            if svc is None:
-                return None
-            price_map = svc.get_type_price_map(type_ids=[type_id], hub=hub, side="buy")
+            price_map = self._market_pricing.get_type_price_map(type_ids=[type_id], hub=hub, side="buy")
             if type_id in price_map:
                 return float(price_map[type_id].get("unit_price") or 0) or None
         except Exception as exc:
@@ -326,6 +353,71 @@ class PricingSuggestionService:
         upper_fence = q3 + 2.0 * iqr
         filtered = [lv for lv in levels if float(lv[0]) <= upper_fence]
         return filtered if len(filtered) >= 2 else levels[:2]
+
+    # ── EVE price tick helpers ────────────────────────────────────────────────
+
+    @staticmethod
+    def _eve_price_tick(price: float) -> float:
+        """Minimum ISK increment for a price in EVE Online.
+
+        EVE allows only 4 significant figures when modifying an order price.
+        Digits below the 4th most-significant figure are zeroed out, so the
+        effective tick is 10^(floor(log10(price)) - 3), capped at 0.01 ISK.
+        Examples:
+          1,500,000 ISK → tick 1,000 ISK
+            150,000 ISK → tick   100 ISK
+             15,000 ISK → tick    10 ISK
+              1,500 ISK → tick     1 ISK
+                150 ISK → tick   0.1 ISK
+                 15 ISK → tick  0.01 ISK
+        """
+        if price <= 0:
+            return 0.01
+        magnitude = math.floor(math.log10(price))
+        return max(0.01, 10.0 ** (magnitude - 3))
+
+    @staticmethod
+    def _snap_to_eve_tick(price: float) -> float:
+        """Floor price DOWN to the nearest valid EVE market tick.
+
+        Snapping down (not rounding) ensures the output never exceeds the
+        intended price — important when the caller uses the result as an
+        undercut target or a margin floor.
+        """
+        if price <= 0:
+            return round(price, 2)
+        tick = PricingSuggestionService._eve_price_tick(price)
+        return round(math.floor(price / tick) * tick, 2)
+
+    def _find_gap_position(
+        self,
+        *,
+        current_price: float,
+        orderbook_levels: list[list[float]],
+        floor_price: float,
+    ) -> float | None:
+        """Find the highest valid price that still beats the nearest undercutting order.
+
+        When being undercut, the optimal strategy is not to chase the absolute
+        cheapest price but to position 1 EVE tick below the nearest competitor
+        that is cheaper than the current price — capturing the gap between
+        adjacent price clusters.
+
+        Example (Bustard):
+          Orderbook: ...170,000,000 | 171,000,000 | 171,100,000 (your order)
+          Nearest undercutter: 171,000,000
+          Tick at 171M: 100,000
+          Gap position: 170,900,000  (beats the 171M sellers by 1 tick, no need to go lower)
+        """
+        if not orderbook_levels or current_price <= 0:
+            return None
+        prices_below = [float(lv[0]) for lv in orderbook_levels if float(lv[0]) < current_price]
+        if not prices_below:
+            return None  # already front of queue — handled by front-of-queue guard
+        nearest_undercut = max(prices_below)
+        tick = self._eve_price_tick(nearest_undercut)
+        gap_top = self._snap_to_eve_tick(nearest_undercut) - tick
+        return gap_top if gap_top >= floor_price else None
 
     # ── Market microstructure signals ─────────────────────────────────────────
 
@@ -709,17 +801,22 @@ class PricingSuggestionService:
 
         if orderbook_levels:
             cheapest_competing = orderbook_levels[0][0]
+            # Undercut by exactly 1 EVE tick (the minimum price change EVE allows)
+            eve_tick = self._eve_price_tick(cheapest_competing)
+            undercut_price = self._snap_to_eve_tick(cheapest_competing) - eve_tick
             if current_price <= cheapest_competing:
-                price_aggressive = max(floor, current_price)
+                # Already front of queue — hold current price (snapped to valid tick)
+                price_aggressive = max(floor, self._snap_to_eve_tick(current_price))
             else:
-                price_aggressive = max(floor, cheapest_competing - 0.01)
+                price_aggressive = max(floor, undercut_price)
         else:
             price_aggressive = floor
 
         price_aggressive = min(price_aggressive, target_price)
         price_aggressive = max(price_aggressive, floor)
+        price_aggressive = self._snap_to_eve_tick(price_aggressive)
 
-        price_target = target_price
+        price_target = self._snap_to_eve_tick(target_price)
 
         trend_pct = float(market_data.get("trend_pct") or 0) if market_data.get("has_data") else 0.0
         if hub_price and hub_price > 0 and trend_pct > 2:
@@ -731,6 +828,7 @@ class PricingSuggestionService:
         else:
             price_premium = price_target
             premium_label = "Market not trending up — same as target"
+        price_premium = self._snap_to_eve_tick(price_premium)
 
         def _tier_metrics(price: float) -> dict[str, Any]:
             est_d = self._estimate_sell_days(
@@ -864,6 +962,11 @@ class PricingSuggestionService:
         if breakdown.get("floored_to_target_margin"):
             m = breakdown.get("min_target_margin_pct", 8)
             reasoning += f" (Price raised to meet {m}% target margin.)"
+        if breakdown.get("gap_positioned"):
+            gap = breakdown.get("gap_price", 0)
+            reasoning += f" (Gap positioning: raised to {gap:,.0f} ISK — 1 tick below nearest undercutting order.)"
+        if breakdown.get("already_front_of_queue"):
+            reasoning += " (Already cheapest at hub — held at current price, no undercut needed.)"
         if breakdown.get("urgency_adjusted"):
             blend_pct = round((breakdown.get("urgency_blend", 0)) * 100)
             reasoning += f" (Expiry urgency: price moved {blend_pct}% toward aggressive tier.)"

--- a/src/eve_online_industry_tracker/application/market_analysis/pricing_suggestion_service.py
+++ b/src/eve_online_industry_tracker/application/market_analysis/pricing_suggestion_service.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import json
+import logging
 from typing import Any
 
 from sqlalchemy import and_
 from eve_online_industry_tracker.application.industry.sales_history_service import SalesHistoryService
 from eve_online_industry_tracker.application.market_analysis.market_history_service import MarketHistoryService
-from eve_online_industry_tracker.infrastructure.models import CharacterAssetsModel
+from eve_online_industry_tracker.infrastructure.models import CharacterAssetsModel, CharacterModel
 from eve_online_industry_tracker.infrastructure.session_provider import SessionProvider, StateSessionProvider
 
 
@@ -26,6 +28,8 @@ class PricingSuggestionService:
         current_price: float,
         hub: str = "jita",
         region_id: int = 10000002,
+        quantity: int = 0,
+        order_duration_days: int = 90,
     ) -> dict[str, Any]:
         """Suggest a sell price with detailed breakdown.
 
@@ -35,6 +39,12 @@ class PricingSuggestionService:
         - breakdown: detailed component analysis for UI
         - reasoning: human-readable explanation
         - cost_basis_source: 'asset' or 'market_order_fallback' or None
+        - break_even_price: minimum list price for profit after fees
+        - net_margin_pct_advised / net_margin_pct_current: margin % after fees
+        - estimated_sell_days_advised / estimated_sell_days_current
+        - isk_per_day_advised / isk_per_day_current
+        - hold_signal: dict with hold recommendation and reasoning
+        - relist_risk: dict flagging if order may expire before selling
         """
         # Get all inputs
         my_sales = self._sales_history.suggest_sell_price(character_id=character_id, type_id=type_id)
@@ -49,6 +59,10 @@ class PricingSuggestionService:
         # Fetch current market hub price
         hub_price = self._get_hub_price(type_id=type_id, hub=hub)
 
+        # Fetch character fees and orderbook queue for profitability metrics
+        sales_tax, broker_fee = self._get_fees(character_id=character_id)
+        orderbook_levels = self._get_orderbook_levels(type_id=type_id, region_id=region_id)
+
         # Calculate weighted price
         breakdown = self._calculate_breakdown(
             my_sales=my_sales,
@@ -62,6 +76,18 @@ class PricingSuggestionService:
         advised_price = breakdown["weighted_price"]
         confidence = self._assess_confidence(my_sales, market_data, volume_data, cost_basis)
 
+        # Profitability and velocity metrics
+        avg_daily_vol = float(volume_data.get("avg_daily_volume", 0)) if volume_data.get("has_data") else 0.0
+        break_even = self._calc_break_even(cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
+        net_margin_advised = self._calc_net_margin(price=advised_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
+        net_margin_current = self._calc_net_margin(price=current_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
+        est_days_advised = self._estimate_sell_days(target_price=advised_price, quantity=quantity, orderbook_levels=orderbook_levels, avg_daily_volume=avg_daily_vol)
+        est_days_current = self._estimate_sell_days(target_price=current_price, quantity=quantity, orderbook_levels=orderbook_levels, avg_daily_volume=avg_daily_vol)
+        isk_per_day_advised = self._calc_isk_per_day(price=advised_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee, quantity=quantity, est_days=est_days_advised)
+        isk_per_day_current = self._calc_isk_per_day(price=current_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee, quantity=quantity, est_days=est_days_current)
+        hold_signal = self._calc_hold_signal(market_data=market_data, hub_price=hub_price, quantity=quantity, isk_per_day_advised=isk_per_day_advised)
+        relist_risk = self._calc_relist_risk(est_days=est_days_advised, order_duration_days=order_duration_days, broker_fee=broker_fee, price=advised_price, quantity=quantity)
+
         return {
             "advised_price": advised_price,
             "confidence": confidence,
@@ -73,11 +99,26 @@ class PricingSuggestionService:
             "cost_basis_source": cost_source,
             "breakdown": breakdown,
             "reasoning": self._build_reasoning(breakdown, confidence),
+            # Fee metadata
+            "sales_tax_fraction": sales_tax,
+            "broker_fee_fraction": broker_fee,
+            # Profitability
+            "break_even_price": break_even,
+            "net_margin_pct_advised": net_margin_advised,
+            "net_margin_pct_current": net_margin_current,
+            # Sell velocity
+            "estimated_sell_days_advised": est_days_advised,
+            "estimated_sell_days_current": est_days_current,
+            # Combined metric
+            "isk_per_day_advised": isk_per_day_advised,
+            "isk_per_day_current": isk_per_day_current,
+            # Signals
+            "hold_signal": hold_signal,
+            "relist_risk": relist_risk,
         }
 
     def _get_hub_price(self, *, type_id: int, hub: str = "jita") -> float | None:
         """Get current hub price from market pricing service."""
-        import logging
         try:
             pricing_service = getattr(self._state, "market_pricing_service", None)
             if pricing_service is None:
@@ -105,7 +146,6 @@ class PricingSuggestionService:
         Returns: (cost_basis, acquisition_source, cost_source)
         where cost_source is 'asset', 'market_order_fallback', or None
         """
-        import logging
         app_session = self._sessions.app_session()
         try:
             assets = app_session.query(CharacterAssetsModel).filter(
@@ -117,7 +157,6 @@ class PricingSuggestionService:
 
             if not assets:
                 logging.debug(f"Cost basis: no assets found (char_id={character_id}, type_id={type_id})")
-                # Fallback to market order price if available (ESI data inconsistency workaround)
                 if fallback_price and fallback_price > 0:
                     logging.debug(f"Cost basis: using market order price as fallback ({fallback_price})")
                     return fallback_price, "market_order_fallback", "market_order_fallback"
@@ -138,7 +177,6 @@ class PricingSuggestionService:
 
             if total_quantity > 0:
                 avg_cost = total_cost / total_quantity
-                # Prefer more specific sources
                 source = None
                 if "manufactured" in sources:
                     source = "manufactured"
@@ -151,7 +189,6 @@ class PricingSuggestionService:
                 return avg_cost, source, "asset"
 
             logging.debug(f"Cost basis: found {len(assets)} asset(s) but none with costs, char_id={character_id}, type_id={type_id}")
-            # Fallback to market order price if no cost data on assets
             if fallback_price and fallback_price > 0:
                 logging.debug(f"Cost basis: using market order price as fallback for assetless item ({fallback_price})")
                 return fallback_price, "market_order_fallback", "market_order_fallback"
@@ -161,6 +198,52 @@ class PricingSuggestionService:
                 app_session.close()
             except Exception:
                 pass
+
+    def _get_fees(self, *, character_id: int) -> tuple[float, float]:
+        """Return (sales_tax_fraction, broker_fee_fraction) for the character.
+
+        Falls back to EVE defaults (7.5% tax, 3% broker) if not found.
+        """
+        try:
+            app_session = self._sessions.app_session()
+            try:
+                char = app_session.query(CharacterModel).filter(
+                    CharacterModel.character_id == character_id
+                ).first()
+                if char and char.market_fees:
+                    fees = json.loads(char.market_fees) if isinstance(char.market_fees, str) else char.market_fees
+                    if isinstance(fees, dict):
+                        return float(fees.get("sales_tax_fraction", 0.075)), float(fees.get("broker_fee_fraction", 0.03))
+            finally:
+                app_session.close()
+        except Exception as exc:
+            logging.debug(f"_get_fees error (char_id={character_id}): {exc}")
+        return 0.075, 0.03
+
+    def _get_orderbook_levels(self, *, type_id: int, region_id: int = 10000002) -> list[list[float]]:
+        """Return cached Jita sell orderbook levels [[price, volume], ...] sorted ascending by price."""
+        try:
+            from eve_online_industry_tracker.infrastructure.persistence.market_orderbook_cache_repo import get_cached_orderbook_levels
+            app_session = self._sessions.app_session()
+            try:
+                result = get_cached_orderbook_levels(
+                    app_session,
+                    hub="jita",
+                    region_id=region_id,
+                    station_id=60003760,  # Jita 4-4
+                    side="sell",
+                    type_id=type_id,
+                    at_hub=True,
+                    ttl_seconds=3600,
+                )
+                if result is not None:
+                    levels, _ = result
+                    return sorted(levels, key=lambda lv: lv[0])
+            finally:
+                app_session.close()
+        except Exception as exc:
+            logging.debug(f"_get_orderbook_levels error (type_id={type_id}): {exc}")
+        return []
 
     def _calculate_breakdown(
         self,
@@ -232,7 +315,7 @@ class PricingSuggestionService:
                 "reasoning": "Based on market volume and order activity",
             }
 
-        # Calculate weighted price
+        # Calculate weighted price (renormalise weights for missing components)
         total_weight = sum(c.get("weight", 0) for c in components.values())
         if total_weight > 0:
             weighted_price = sum(
@@ -274,6 +357,155 @@ class PricingSuggestionService:
         else:
             # Medium liquidity - neutral
             return current_price
+
+    def _estimate_sell_days(
+        self,
+        *,
+        target_price: float,
+        quantity: int,
+        orderbook_levels: list[list[float]],
+        avg_daily_volume: float,
+    ) -> float | None:
+        """Estimate trading days to sell `quantity` units listed at `target_price`.
+
+        Uses the cached Jita sell orderbook to compute queue depth ahead of our
+        price, then estimates our proportional share of remaining daily volume.
+        """
+        if not quantity or quantity <= 0 or not avg_daily_volume or avg_daily_volume <= 0:
+            return None
+
+        # Volume from sell orders priced strictly below our target (must clear before ours)
+        volume_ahead = sum(int(vol) for price, vol in orderbook_levels if price < target_price)
+
+        # Volume listed at or just above our price (we compete with them for daily demand)
+        volume_at_level = sum(
+            int(vol) for price, vol in orderbook_levels
+            if target_price <= price <= target_price * 1.001
+        )
+
+        # Days until our order reaches the effective front of the queue
+        days_until_front = volume_ahead / avg_daily_volume
+
+        # Proportional share of daily demand: our units vs all units at our level
+        total_at_level = quantity + volume_at_level
+        capture_rate = min(0.50, max(0.05, quantity / total_at_level))
+
+        days_for_our_units = quantity / (avg_daily_volume * capture_rate)
+        return float(days_until_front + days_for_our_units)
+
+    def _calc_break_even(
+        self, *, cost_basis: float | None, sales_tax: float, broker_fee: float
+    ) -> float | None:
+        """Minimum list price to recover cost after sales tax and broker fee."""
+        if not cost_basis or cost_basis <= 0:
+            return None
+        net_rate = 1.0 - sales_tax - broker_fee
+        return float(cost_basis / net_rate) if net_rate > 0 else None
+
+    def _calc_net_margin(
+        self,
+        *,
+        price: float,
+        cost_basis: float | None,
+        sales_tax: float,
+        broker_fee: float,
+    ) -> float | None:
+        """Net profit margin (%) at `price` after sales tax and broker fee."""
+        if not cost_basis or cost_basis <= 0 or not price or price <= 0:
+            return None
+        net_proceeds = price * (1.0 - sales_tax - broker_fee)
+        return float((net_proceeds - cost_basis) / price * 100)
+
+    def _calc_isk_per_day(
+        self,
+        *,
+        price: float,
+        cost_basis: float | None,
+        sales_tax: float,
+        broker_fee: float,
+        quantity: int,
+        est_days: float | None,
+    ) -> float | None:
+        """Total profit ISK per day for this order batch at the given price and sell velocity."""
+        if not cost_basis or cost_basis <= 0 or not quantity or quantity <= 0:
+            return None
+        if not est_days or est_days <= 0:
+            return None
+        profit_per_unit = price * (1.0 - sales_tax - broker_fee) - cost_basis
+        return float(profit_per_unit * quantity / est_days)
+
+    def _calc_hold_signal(
+        self,
+        *,
+        market_data: dict[str, Any],
+        hub_price: float | None,
+        quantity: int,
+        isk_per_day_advised: float | None,
+    ) -> dict[str, Any] | None:
+        """Suggest whether to delay listing when the market trend strongly favours holding."""
+        if not market_data.get("has_data") or not hub_price or hub_price <= 0:
+            return None
+
+        trend_pct = float(market_data.get("trend_pct") or 0)
+        if trend_pct <= 5:
+            return {"suggested": False, "reason": "Market not trending up significantly"}
+
+        # Linear extrapolation: spread the observed 7d-vs-42w trend over 7 calendar days
+        # trend_pct = ((avg_7d - avg_42w) / avg_42w) * 100 — represents drift over 42 weeks
+        daily_rate = trend_pct / (42 * 7)
+        price_in_7d = hub_price * (1.0 + daily_rate * 7)
+        gain_per_unit = price_in_7d - hub_price
+        total_gain = gain_per_unit * max(0, quantity)
+        opportunity_cost_7d = float(isk_per_day_advised or 0) * 7
+
+        if total_gain > opportunity_cost_7d and total_gain > 0:
+            return {
+                "suggested": True,
+                "reason": f"Market +{trend_pct:.1f}% trend; est. +{gain_per_unit:,.0f} ISK/unit in 7d outweighs selling now",
+                "estimated_price_7d": float(price_in_7d),
+                "estimated_gain_total": float(total_gain),
+                "opportunity_cost_7d": float(opportunity_cost_7d),
+            }
+
+        reason = (
+            f"Selling now ({isk_per_day_advised:,.0f} ISK/day) beats waiting for +{trend_pct:.1f}% trend"
+            if isk_per_day_advised
+            else f"Trend +{trend_pct:.1f}% not significant enough to delay"
+        )
+        return {
+            "suggested": False,
+            "reason": reason,
+            "estimated_gain_total": float(total_gain),
+            "opportunity_cost_7d": float(opportunity_cost_7d),
+        }
+
+    def _calc_relist_risk(
+        self,
+        *,
+        est_days: float | None,
+        order_duration_days: int,
+        broker_fee: float,
+        price: float,
+        quantity: int,
+    ) -> dict[str, Any] | None:
+        """Flag if the order is likely to expire before fully selling."""
+        if est_days is None:
+            return None
+        if est_days <= order_duration_days:
+            return {"at_risk": False}
+
+        unsold_fraction = max(0.0, 1.0 - (order_duration_days / est_days))
+        unsold_quantity = max(0, int(quantity * unsold_fraction))
+        relist_cost_estimate = float(price * broker_fee * unsold_quantity)
+
+        return {
+            "at_risk": True,
+            "estimated_sell_days": float(est_days),
+            "order_duration_days": order_duration_days,
+            "estimated_unsold_quantity": unsold_quantity,
+            "estimated_relist_cost": relist_cost_estimate,
+            "reason": f"Est. {est_days:.0f}d to sell exceeds {order_duration_days}d order duration",
+        }
 
     def _assess_confidence(
         self,

--- a/src/eve_online_industry_tracker/application/market_analysis/pricing_suggestion_service.py
+++ b/src/eve_online_industry_tracker/application/market_analysis/pricing_suggestion_service.py
@@ -79,6 +79,14 @@ class PricingSuggestionService:
         # Profitability and velocity metrics
         avg_daily_vol = float(volume_data.get("avg_daily_volume", 0)) if volume_data.get("has_data") else 0.0
         break_even = self._calc_break_even(cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
+
+        # Clamp advised price to fee-aware break-even: the 5% margin floor in
+        # _calculate_breakdown() ignores fees, so the weighted price can still
+        # be a net loss after sales tax + broker fee.
+        if break_even and advised_price < break_even:
+            advised_price = break_even
+            breakdown["weighted_price"] = advised_price
+            breakdown["floored_to_break_even"] = True
         net_margin_advised = self._calc_net_margin(price=advised_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
         net_margin_current = self._calc_net_margin(price=current_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
         est_days_advised = self._estimate_sell_days(target_price=advised_price, quantity=quantity, orderbook_levels=orderbook_levels, avg_daily_volume=avg_daily_vol)
@@ -597,4 +605,6 @@ class PricingSuggestionService:
             parts.append("Market liquidity adjustment")
 
         reasoning = f"Based on: {', '.join(parts)}. Confidence: {confidence}."
+        if breakdown.get("floored_to_break_even"):
+            reasoning += " (Advised price raised to break-even — weighted average did not cover fees.)"
         return reasoning

--- a/src/eve_online_industry_tracker/application/market_analysis/pricing_suggestion_service.py
+++ b/src/eve_online_industry_tracker/application/market_analysis/pricing_suggestion_service.py
@@ -31,62 +31,53 @@ class PricingSuggestionService:
         quantity: int = 0,
         order_duration_days: int = 90,
     ) -> dict[str, Any]:
-        """Suggest a sell price with detailed breakdown.
-
-        Returns dict with:
-        - advised_price: recommended price
-        - confidence: high/medium/low
-        - breakdown: detailed component analysis for UI
-        - reasoning: human-readable explanation
-        - cost_basis_source: 'asset' or 'market_order_fallback' or None
-        - break_even_price: minimum list price for profit after fees
-        - net_margin_pct_advised / net_margin_pct_current: margin % after fees
-        - estimated_sell_days_advised / estimated_sell_days_current
-        - isk_per_day_advised / isk_per_day_current
-        - hold_signal: dict with hold recommendation and reasoning
-        - relist_risk: dict flagging if order may expire before selling
-        """
-        # Get all inputs
+        """Suggest a sell price with detailed breakdown and three-tier price band."""
         my_sales = self._sales_history.suggest_sell_price(character_id=character_id, type_id=type_id)
         market_data = self._market_history.get_price_stats(type_id=type_id, region_id=region_id)
         volume_data = self._market_history.get_volume_stats(type_id=type_id, region_id=region_id)
         cost_basis, acquisition_source, cost_source = self._get_cost_basis(
-            character_id=character_id,
-            type_id=type_id,
-            fallback_price=current_price
+            character_id=character_id, type_id=type_id, fallback_price=current_price
         )
-
-        # Fetch current market hub price
         hub_price = self._get_hub_price(type_id=type_id, hub=hub)
-
-        # Fetch character fees and orderbook queue for profitability metrics
+        hub_buy_price = self._get_hub_buy_price(type_id=type_id, hub=hub)
         sales_tax, broker_fee = self._get_fees(character_id=character_id)
         orderbook_levels = self._get_orderbook_levels(type_id=type_id, region_id=region_id)
+        min_target_margin = self._get_min_target_margin()
 
-        # Calculate weighted price
         breakdown = self._calculate_breakdown(
             my_sales=my_sales,
             market_data=market_data,
             volume_data=volume_data,
             hub_price=hub_price,
+            hub_buy_price=hub_buy_price,
             cost_basis=cost_basis,
             current_price=current_price,
+            orderbook_levels=orderbook_levels,
         )
 
         advised_price = breakdown["weighted_price"]
         confidence = self._assess_confidence(my_sales, market_data, volume_data, cost_basis)
 
-        # Profitability and velocity metrics
         avg_daily_vol = float(volume_data.get("avg_daily_volume", 0)) if volume_data.get("has_data") else 0.0
         break_even = self._calc_break_even(cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
+        min_target_price = self._calc_min_target_price(
+            cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee,
+            min_target_margin=min_target_margin,
+        )
 
-        # Clamp advised price to fee-aware break-even: the 5% margin floor in
-        # _calculate_breakdown() ignores fees, so the weighted price can still
-        # be a net loss after sales tax + broker fee.
+        # Floor 1: break-even — never advise a loss after fees
         if break_even and advised_price < break_even:
             advised_price = break_even
             breakdown["weighted_price"] = advised_price
             breakdown["floored_to_break_even"] = True
+
+        # Floor 2: minimum target margin — respect configured profit target
+        if min_target_price and advised_price < min_target_price:
+            advised_price = min_target_price
+            breakdown["weighted_price"] = advised_price
+            breakdown["floored_to_target_margin"] = True
+            breakdown["min_target_margin_pct"] = round(min_target_margin * 100, 1)
+
         net_margin_advised = self._calc_net_margin(price=advised_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
         net_margin_current = self._calc_net_margin(price=current_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
         est_days_advised = self._estimate_sell_days(target_price=advised_price, quantity=quantity, orderbook_levels=orderbook_levels, avg_daily_volume=avg_daily_vol)
@@ -95,6 +86,20 @@ class PricingSuggestionService:
         isk_per_day_current = self._calc_isk_per_day(price=current_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee, quantity=quantity, est_days=est_days_current)
         hold_signal = self._calc_hold_signal(market_data=market_data, hub_price=hub_price, quantity=quantity, isk_per_day_advised=isk_per_day_advised)
         relist_risk = self._calc_relist_risk(est_days=est_days_advised, order_duration_days=order_duration_days, broker_fee=broker_fee, price=advised_price, quantity=quantity)
+        price_band = self._calc_price_band(
+            target_price=advised_price,
+            min_target_price=min_target_price,
+            break_even_price=break_even,
+            hub_price=hub_price,
+            orderbook_levels=orderbook_levels,
+            current_price=current_price,
+            market_data=market_data,
+            cost_basis=cost_basis,
+            sales_tax=sales_tax,
+            broker_fee=broker_fee,
+            quantity=quantity,
+            avg_daily_vol=avg_daily_vol,
+        )
 
         return {
             "advised_price": advised_price,
@@ -107,58 +112,61 @@ class PricingSuggestionService:
             "cost_basis_source": cost_source,
             "breakdown": breakdown,
             "reasoning": self._build_reasoning(breakdown, confidence),
-            # Fee metadata
             "sales_tax_fraction": sales_tax,
             "broker_fee_fraction": broker_fee,
-            # Profitability
+            "min_target_margin_pct": round(min_target_margin * 100, 1),
             "break_even_price": break_even,
             "net_margin_pct_advised": net_margin_advised,
             "net_margin_pct_current": net_margin_current,
-            # Sell velocity
             "estimated_sell_days_advised": est_days_advised,
             "estimated_sell_days_current": est_days_current,
-            # Combined metric
             "isk_per_day_advised": isk_per_day_advised,
             "isk_per_day_current": isk_per_day_current,
-            # Signals
             "hold_signal": hold_signal,
             "relist_risk": relist_risk,
+            "price_band": price_band,
         }
 
-    def _get_hub_price(self, *, type_id: int, hub: str = "jita") -> float | None:
-        """Get current hub price from market pricing service."""
-        try:
-            pricing_service = getattr(self._state, "market_pricing_service", None)
-            if pricing_service is None:
-                logging.debug(f"Hub price: market_pricing_service not available (type_id={type_id})")
-                return None
+    # ── Data retrieval ────────────────────────────────────────────────────────
 
-            price_map = pricing_service.get_type_price_map(
-                type_ids=[type_id],
-                hub=hub,
-                side="sell",
-            )
+    def _get_hub_price(self, *, type_id: int, hub: str = "jita") -> float | None:
+        """Current best Jita sell price from market pricing service."""
+        try:
+            svc = getattr(self._state, "market_pricing_service", None)
+            if svc is None:
+                return None
+            price_map = svc.get_type_price_map(type_ids=[type_id], hub=hub, side="sell")
             if type_id in price_map:
-                hub_price = float(price_map[type_id].get("unit_price") or 0)
-                logging.debug(f"Hub price (type_id={type_id}, {hub}): {hub_price}")
-                return hub_price
-            else:
-                logging.debug(f"Hub price: type_id {type_id} not in price_map")
-        except Exception as e:
-            logging.debug(f"Hub price error (type_id={type_id}): {e}")
+                return float(price_map[type_id].get("unit_price") or 0) or None
+        except Exception as exc:
+            logging.debug(f"_get_hub_price error (type_id={type_id}): {exc}")
         return None
 
-    def _get_cost_basis(self, *, character_id: int, type_id: int, fallback_price: float | None = None) -> tuple[float | None, str | None, str | None]:
-        """Get average acquisition cost and source for items in inventory.
+    def _get_hub_buy_price(self, *, type_id: int, hub: str = "jita") -> float | None:
+        """Best Jita buy order price — used to compute the buy-sell spread."""
+        try:
+            svc = getattr(self._state, "market_pricing_service", None)
+            if svc is None:
+                return None
+            price_map = svc.get_type_price_map(type_ids=[type_id], hub=hub, side="buy")
+            if type_id in price_map:
+                return float(price_map[type_id].get("unit_price") or 0) or None
+        except Exception as exc:
+            logging.debug(f"_get_hub_buy_price error (type_id={type_id}): {exc}")
+        return None
 
-        Returns: (cost_basis, acquisition_source, cost_source)
+    def _get_cost_basis(
+        self, *, character_id: int, type_id: int, fallback_price: float | None = None
+    ) -> tuple[float | None, str | None, str | None]:
+        """Weighted-average acquisition cost for an item.
 
-        cost_source values:
-          'asset'                — weighted avg from current CharacterAssetsModel rows
-          'asset_history'        — most recent CharacterAssetHistoryModel record
-                                   (used when item is listed on market and absent
-                                   from the current assets snapshot)
-          'market_order_fallback' — neither assets nor history found; order price used
+        Priority:
+          1. Current CharacterAssetsModel rows (item in hangar)
+          2. Most recent CharacterAssetHistoryModel row (item on market — ESI removes
+             active sell orders from the assets snapshot)
+          3. Current order price as last resort (unreliable; triggers warning)
+
+        Returns (cost_basis, acquisition_source, cost_source).
         """
         app_session = self._sessions.app_session()
         try:
@@ -172,8 +180,7 @@ class PricingSuggestionService:
             if assets:
                 total_cost = 0.0
                 total_quantity = 0
-                sources = set()
-
+                sources: set[str] = set()
                 for asset in assets:
                     cost = asset.acquisition_unit_cost
                     qty = asset.quantity
@@ -182,23 +189,15 @@ class PricingSuggestionService:
                         total_quantity += qty
                     if asset.acquisition_source:
                         sources.add(asset.acquisition_source)
-
                 if total_quantity > 0:
                     avg_cost = total_cost / total_quantity
-                    source = None
-                    if "manufactured" in sources:
-                        source = "manufactured"
-                    elif "bought" in sources or "market" in sources:
-                        source = "bought"
-                    elif sources:
-                        source = list(sources)[0]
-
-                    logging.debug(f"Cost basis found: {avg_cost} ({source}), char_id={character_id}, type_id={type_id}")
+                    source = (
+                        "manufactured" if "manufactured" in sources
+                        else "bought" if "bought" in sources or "market" in sources
+                        else list(sources)[0] if sources else None
+                    )
                     return avg_cost, source, "asset"
 
-            # Item is likely listed on market — ESI removes active sell orders from
-            # the assets endpoint. Fall back to the most recent asset history record.
-            logging.debug(f"Cost basis: no current assets with cost (char_id={character_id}, type_id={type_id}), checking history")
             history_row = (
                 app_session.query(CharacterAssetHistoryModel)
                 .filter(
@@ -212,13 +211,9 @@ class PricingSuggestionService:
                 .first()
             )
             if history_row and history_row.acquisition_unit_cost and history_row.acquisition_unit_cost > 0:
-                source = history_row.acquisition_source or "unknown"
-                logging.debug(f"Cost basis from history: {history_row.acquisition_unit_cost} ({source})")
-                return float(history_row.acquisition_unit_cost), source, "asset_history"
+                return float(history_row.acquisition_unit_cost), history_row.acquisition_source or "unknown", "asset_history"
 
-            # Last resort: use the order's own price as a rough proxy
             if fallback_price and fallback_price > 0:
-                logging.debug(f"Cost basis: using market order price as fallback ({fallback_price})")
                 return fallback_price, "market_order_fallback", "market_order_fallback"
             return None, None, None
         finally:
@@ -228,10 +223,7 @@ class PricingSuggestionService:
                 pass
 
     def _get_fees(self, *, character_id: int) -> tuple[float, float]:
-        """Return (sales_tax_fraction, broker_fee_fraction) for the character.
-
-        Falls back to EVE defaults (7.5% tax, 3% broker) if not found.
-        """
+        """(sales_tax_fraction, broker_fee_fraction) — falls back to EVE defaults."""
         try:
             app_session = self._sessions.app_session()
             try:
@@ -249,20 +241,15 @@ class PricingSuggestionService:
         return 0.075, 0.03
 
     def _get_orderbook_levels(self, *, type_id: int, region_id: int = 10000002) -> list[list[float]]:
-        """Return cached Jita sell orderbook levels [[price, volume], ...] sorted ascending by price."""
+        """Cached Jita 4-4 sell orderbook [[price, volume], ...] sorted ascending."""
         try:
             from eve_online_industry_tracker.infrastructure.persistence.market_orderbook_cache_repo import get_cached_orderbook_levels
             app_session = self._sessions.app_session()
             try:
                 result = get_cached_orderbook_levels(
                     app_session,
-                    hub="jita",
-                    region_id=region_id,
-                    station_id=60003760,  # Jita 4-4
-                    side="sell",
-                    type_id=type_id,
-                    at_hub=True,
-                    ttl_seconds=3600,
+                    hub="jita", region_id=region_id, station_id=60003760,
+                    side="sell", type_id=type_id, at_hub=True, ttl_seconds=3600,
                 )
                 if result is not None:
                     levels, _ = result
@@ -273,6 +260,21 @@ class PricingSuggestionService:
             logging.debug(f"_get_orderbook_levels error (type_id={type_id}): {exc}")
         return []
 
+    def _get_min_target_margin(self) -> float:
+        """Minimum acceptable net profit margin (fraction). Configurable via cfg_manager."""
+        try:
+            cfg_manager = getattr(self._state, "cfg_manager", None)
+            if cfg_manager:
+                cfg = cfg_manager.all() or {}
+                advisory_cfg = ((cfg.get("defaults") or {}).get("market_advisory") or {})
+                if "min_target_margin_pct" in advisory_cfg:
+                    return max(0.0, min(0.50, float(advisory_cfg["min_target_margin_pct"]) / 100))
+        except Exception:
+            pass
+        return 0.08  # 8 % default
+
+    # ── Core price calculation ────────────────────────────────────────────────
+
     def _calculate_breakdown(
         self,
         *,
@@ -280,18 +282,25 @@ class PricingSuggestionService:
         market_data: dict[str, Any],
         volume_data: dict[str, Any],
         hub_price: float | None,
+        hub_buy_price: float | None,
         cost_basis: float | None,
         current_price: float,
+        orderbook_levels: list[list[float]],
     ) -> dict[str, Any]:
-        """Calculate components and weighted price."""
-        components = {}
+        """Build weighted-price components.
 
-        # Component 0: Your cost basis (15% weight) - floor price
+        Improvements vs original:
+          B — Hub price weight dampened by volatility (high vol = less hub anchoring)
+          A — Days-of-supply replaces the old three-bucket liquidity adjustment
+          C — Buy-sell spread added as a demand-pressure signal
+        """
+        components: dict[str, Any] = {}
+        volatility_pct = float(market_data.get("volatility_pct") or 0) if market_data.get("has_data") else 0.0
+
+        # Component 0: Your cost basis (15% weight) — soft floor
         if cost_basis and cost_basis > 0:
-            # Add 5% margin on top of cost basis as the floor
-            cost_with_margin = cost_basis * 1.05
             components["your_cost_basis"] = {
-                "value": float(cost_with_margin),
+                "value": float(cost_basis * 1.05),
                 "weight": 0.15,
                 "raw_cost": float(cost_basis),
                 "margin_pct": 5,
@@ -307,58 +316,63 @@ class PricingSuggestionService:
                 "confidence": my_sales.get("confidence", "none"),
             }
 
-        # Component 2: Current market hub price (35% weight)
+        # Component 2: Hub price — B: weight dampened by volatility
+        # High volatility → hub snapshot is less reliable → redistribute to other signals
         if hub_price and hub_price > 0:
+            hub_weight = max(0.15, 0.35 / (1.0 + volatility_pct / 100.0))
             components["market_hub_price"] = {
                 "value": float(hub_price),
-                "weight": 0.35,
+                "weight": hub_weight,
+                "volatility_pct": volatility_pct,
+                "volatility_dampened": volatility_pct > 10,
             }
 
         # Component 3: Market trend (15% weight)
-        market_trend_price = None
         if market_data.get("has_data"):
-            avg_42w = market_data.get("avg_42w", 0)
-            avg_7d = market_data.get("avg_7d", 0)
-            trend_pct = market_data.get("trend_pct", 0)
-
-            # If trending down, be more conservative; if trending up, can price higher
-            adjustment_factor = 1.0 + (trend_pct / 100 * 0.5)  # 50% of trend impact
-            market_trend_price = avg_42w * adjustment_factor if avg_42w > 0 else None
-
-            if market_trend_price:
+            avg_42w = market_data.get("avg_42w") or 0
+            avg_7d = market_data.get("avg_7d") or 0
+            trend_pct = market_data.get("trend_pct") or 0
+            adjustment_factor = 1.0 + (trend_pct / 100.0 * 0.5)
+            trend_price = avg_42w * adjustment_factor if avg_42w > 0 else None
+            if trend_price:
                 components["market_trend"] = {
-                    "value": float(market_trend_price),
+                    "value": float(trend_price),
                     "weight": 0.15,
                     "trend_pct": trend_pct,
                     "avg_42w": float(avg_42w),
                     "avg_7d": float(avg_7d),
                 }
 
-        # Component 4: Liquidity/Undercut adjustment (15% weight)
-        liquidity_adjustment = self._calc_liquidity_adjustment(volume_data, current_price)
-        if liquidity_adjustment:
-            components["liquidity_adjustment"] = {
-                "value": float(liquidity_adjustment),
-                "weight": 0.15,
-                "reasoning": "Based on market volume and order activity",
-            }
+        # Component 4: A — Days-of-supply (replaces three-bucket liquidity adjustment)
+        supply_signal = self._calc_supply_demand_signal(
+            orderbook_levels=orderbook_levels,
+            volume_data=volume_data,
+            hub_price=hub_price,
+            current_price=current_price,
+        )
+        if supply_signal:
+            components["supply_demand"] = supply_signal
 
-        # Calculate weighted price (renormalise weights for missing components)
+        # Component 5: C — Buy-sell spread demand pressure (if buy price available)
+        spread_signal = self._calc_buy_sell_spread_signal(
+            hub_sell_price=hub_price,
+            hub_buy_price=hub_buy_price,
+        )
+        if spread_signal:
+            components["buy_sell_spread"] = spread_signal
+
+        # Weighted price — renormalise across present components
         total_weight = sum(c.get("weight", 0) for c in components.values())
         if total_weight > 0:
             weighted_price = sum(
-                c.get("value", 0) * c.get("weight", 0)
-                for c in components.values()
-                if c.get("value", 0) > 0
+                c["value"] * c["weight"] for c in components.values() if c.get("value", 0) > 0
             ) / total_weight
         else:
             weighted_price = current_price
 
-        # Ensure we never go below cost basis (with margin)
+        # Soft floor: cost + 5% (fee-aware hard floors applied in suggest_price)
         if cost_basis and cost_basis > 0:
-            min_price = cost_basis * 1.05
-            if weighted_price < min_price:
-                weighted_price = min_price
+            weighted_price = max(weighted_price, cost_basis * 1.05)
 
         return {
             "components": components,
@@ -366,79 +380,121 @@ class PricingSuggestionService:
             "total_weight": total_weight,
         }
 
-    def _calc_liquidity_adjustment(
-        self,
-        volume_data: dict[str, Any],
-        current_price: float,
-    ) -> float | None:
-        """Calculate price adjustment based on liquidity."""
-        if not volume_data.get("has_data"):
-            return None
-
-        avg_vol = volume_data.get("avg_daily_volume", 0)
-        if avg_vol < 100:
-            # Low liquidity - be more cautious
-            return current_price * 0.95
-        elif avg_vol > 10000:
-            # High liquidity - can be more aggressive
-            return current_price * 1.02
-        else:
-            # Medium liquidity - neutral
-            return current_price
-
-    def _estimate_sell_days(
+    def _calc_supply_demand_signal(
         self,
         *,
-        target_price: float,
-        quantity: int,
         orderbook_levels: list[list[float]],
-        avg_daily_volume: float,
-    ) -> float | None:
-        """Estimate trading days to sell `quantity` units listed at `target_price`.
+        volume_data: dict[str, Any],
+        hub_price: float | None,
+        current_price: float,
+    ) -> dict[str, Any] | None:
+        """A — Days-of-supply signal replacing the old liquidity bucket.
 
-        Uses the cached Jita sell orderbook to compute queue depth ahead of our
-        price, then estimates our proportional share of remaining daily volume.
+        days_of_supply = total sell volume in orderbook / avg daily volume
+          > 30 days → oversupplied  → price conservatively
+          7–30 days → balanced      → price at reference
+          < 7 days  → undersupplied → can hold above reference
         """
-        if not quantity or quantity <= 0 or not avg_daily_volume or avg_daily_volume <= 0:
+        if not volume_data.get("has_data"):
+            return None
+        avg_daily_volume = float(volume_data.get("avg_daily_volume") or 0)
+        if avg_daily_volume <= 0 or not orderbook_levels:
             return None
 
-        # Volume from sell orders priced strictly below our target (must clear before ours)
-        volume_ahead = sum(int(vol) for price, vol in orderbook_levels if price < target_price)
+        total_sell_volume = sum(int(vol) for _, vol in orderbook_levels)
+        if total_sell_volume <= 0:
+            return None
 
-        # Volume listed at or just above our price (we compete with them for daily demand)
-        volume_at_level = sum(
-            int(vol) for price, vol in orderbook_levels
-            if target_price <= price <= target_price * 1.001
-        )
+        days_of_supply = total_sell_volume / avg_daily_volume
+        reference = hub_price or current_price
 
-        # Days until our order reaches the effective front of the queue
-        days_until_front = volume_ahead / avg_daily_volume
+        if days_of_supply > 30:
+            signal_price = reference * 0.97
+            label = f"oversupplied ({days_of_supply:.0f}d supply) — price conservatively"
+        elif days_of_supply < 7:
+            signal_price = reference * 1.03
+            label = f"undersupplied ({days_of_supply:.1f}d supply) — can hold premium"
+        else:
+            signal_price = reference
+            label = f"balanced ({days_of_supply:.0f}d supply)"
 
-        # Proportional share of daily demand: our units vs all units at our level
-        total_at_level = quantity + volume_at_level
-        capture_rate = min(0.50, max(0.05, quantity / total_at_level))
+        return {
+            "value": float(signal_price),
+            "weight": 0.15,
+            "days_of_supply": round(days_of_supply, 1),
+            "total_sell_volume": int(total_sell_volume),
+            "avg_daily_volume": round(avg_daily_volume, 0),
+            "label": label,
+        }
 
-        days_for_our_units = quantity / (avg_daily_volume * capture_rate)
-        return float(days_until_front + days_for_our_units)
+    def _calc_buy_sell_spread_signal(
+        self,
+        *,
+        hub_sell_price: float | None,
+        hub_buy_price: float | None,
+    ) -> dict[str, Any] | None:
+        """C — Buy-sell spread as a demand pressure signal.
+
+        Tight spread (<5%)  → buyers are close to the ask → demand is strong
+        Normal spread (5-25%) → neutral
+        Wide spread (>25%)  → thin demand → price more conservatively
+        """
+        if not hub_sell_price or hub_sell_price <= 0 or not hub_buy_price or hub_buy_price <= 0:
+            return None
+        if hub_buy_price >= hub_sell_price:
+            return None
+
+        spread_pct = (hub_sell_price - hub_buy_price) / hub_sell_price * 100
+
+        if spread_pct < 5:
+            # Tight: buyers close to ask — slight premium possible
+            signal_price = hub_sell_price * 1.01
+            label = f"tight spread ({spread_pct:.1f}%) — strong demand"
+        elif spread_pct > 25:
+            # Wide: thin demand — approach midpoint pricing
+            midpoint = (hub_sell_price + hub_buy_price) / 2
+            signal_price = midpoint
+            label = f"wide spread ({spread_pct:.1f}%) — thin demand, price conservatively"
+        else:
+            signal_price = hub_sell_price
+            label = f"normal spread ({spread_pct:.1f}%)"
+
+        return {
+            "value": float(signal_price),
+            "weight": 0.10,
+            "spread_pct": round(spread_pct, 1),
+            "hub_sell_price": float(hub_sell_price),
+            "hub_buy_price": float(hub_buy_price),
+            "label": label,
+        }
+
+    # ── Profitability helpers ─────────────────────────────────────────────────
 
     def _calc_break_even(
         self, *, cost_basis: float | None, sales_tax: float, broker_fee: float
     ) -> float | None:
-        """Minimum list price to recover cost after sales tax and broker fee."""
         if not cost_basis or cost_basis <= 0:
             return None
         net_rate = 1.0 - sales_tax - broker_fee
         return float(cost_basis / net_rate) if net_rate > 0 else None
 
-    def _calc_net_margin(
+    def _calc_min_target_price(
         self,
         *,
-        price: float,
         cost_basis: float | None,
         sales_tax: float,
         broker_fee: float,
+        min_target_margin: float,
     ) -> float | None:
-        """Net profit margin (%) at `price` after sales tax and broker fee."""
+        """Minimum list price to achieve the configured profit margin after fees."""
+        if not cost_basis or cost_basis <= 0 or min_target_margin <= 0:
+            return None
+        net_rate = 1.0 - min_target_margin - sales_tax - broker_fee
+        return float(cost_basis / net_rate) if net_rate > 0 else None
+
+    def _calc_net_margin(
+        self, *, price: float, cost_basis: float | None, sales_tax: float, broker_fee: float
+    ) -> float | None:
         if not cost_basis or cost_basis <= 0 or not price or price <= 0:
             return None
         net_proceeds = price * (1.0 - sales_tax - broker_fee)
@@ -454,13 +510,146 @@ class PricingSuggestionService:
         quantity: int,
         est_days: float | None,
     ) -> float | None:
-        """Total profit ISK per day for this order batch at the given price and sell velocity."""
         if not cost_basis or cost_basis <= 0 or not quantity or quantity <= 0:
             return None
         if not est_days or est_days <= 0:
             return None
         profit_per_unit = price * (1.0 - sales_tax - broker_fee) - cost_basis
         return float(profit_per_unit * quantity / est_days)
+
+    # ── Velocity ──────────────────────────────────────────────────────────────
+
+    def _estimate_sell_days(
+        self,
+        *,
+        target_price: float,
+        quantity: int,
+        orderbook_levels: list[list[float]],
+        avg_daily_volume: float,
+    ) -> float | None:
+        if not quantity or quantity <= 0 or not avg_daily_volume or avg_daily_volume <= 0:
+            return None
+        volume_ahead = sum(int(vol) for price, vol in orderbook_levels if price < target_price)
+        volume_at_level = sum(
+            int(vol) for price, vol in orderbook_levels
+            if target_price <= price <= target_price * 1.001
+        )
+        days_until_front = volume_ahead / avg_daily_volume
+        total_at_level = quantity + volume_at_level
+        capture_rate = min(0.50, max(0.05, quantity / total_at_level))
+        days_for_our_units = quantity / (avg_daily_volume * capture_rate)
+        return float(days_until_front + days_for_our_units)
+
+    # ── Price band ────────────────────────────────────────────────────────────
+
+    def _calc_price_band(
+        self,
+        *,
+        target_price: float,
+        min_target_price: float | None,
+        break_even_price: float | None,
+        hub_price: float | None,
+        orderbook_levels: list[list[float]],
+        current_price: float,
+        market_data: dict[str, Any],
+        cost_basis: float | None,
+        sales_tax: float,
+        broker_fee: float,
+        quantity: int,
+        avg_daily_vol: float,
+    ) -> dict[str, Any]:
+        """F — Three-tier price band: aggressive / target / premium.
+
+        Aggressive — fastest sell, at or above minimum target margin floor.
+          • If our current price is already at or below the cheapest queue entry
+            (we're at the front), aggressive = target (no need to undercut further).
+          • Otherwise, undercut the cheapest competing sell by 0.01 ISK, but never
+            below the minimum target margin price.
+
+        Target — optimal ISK/day; the current advised price after all floors.
+
+        Premium — best margin, slower sell.
+          • Projects the market trend forward 14 days.
+          • Capped at hub_price × 1.25 to avoid absurd suggestions.
+          • Only offered when trend_pct > 2 %; otherwise equals target.
+        """
+        floor = min_target_price or break_even_price or target_price
+
+        # Aggressive
+        if orderbook_levels:
+            cheapest_competing = orderbook_levels[0][0]
+            if current_price <= cheapest_competing:
+                # We're already at the front — don't go lower
+                price_aggressive = max(floor, current_price)
+            else:
+                price_aggressive = max(floor, cheapest_competing - 0.01)
+        else:
+            price_aggressive = floor
+
+        # Aggressive is always ≤ target (it's the fast-sell option, not a premium)
+        price_aggressive = min(price_aggressive, target_price)
+        price_aggressive = max(price_aggressive, floor)
+
+        # Target (= advised price)
+        price_target = target_price
+
+        # Premium
+        trend_pct = float(market_data.get("trend_pct") or 0) if market_data.get("has_data") else 0.0
+        if hub_price and hub_price > 0 and trend_pct > 2:
+            daily_rate = trend_pct / (42 * 7)
+            price_premium = hub_price * (1.0 + daily_rate * 14)
+            price_premium = min(price_premium, hub_price * 1.25)
+            price_premium = max(price_premium, price_target)
+            premium_label = f"Hold for trend (+{trend_pct:.1f}% 42w, 14d projection)"
+        else:
+            price_premium = price_target
+            premium_label = "Market not trending up — same as target"
+
+        # Compute sell days and ISK/day for aggressive and premium for UI context
+        est_days_aggressive = self._estimate_sell_days(
+            target_price=price_aggressive, quantity=quantity,
+            orderbook_levels=orderbook_levels, avg_daily_volume=avg_daily_vol,
+        )
+        est_days_premium = self._estimate_sell_days(
+            target_price=price_premium, quantity=quantity,
+            orderbook_levels=orderbook_levels, avg_daily_volume=avg_daily_vol,
+        )
+        isk_day_aggressive = self._calc_isk_per_day(
+            price=price_aggressive, cost_basis=cost_basis, sales_tax=sales_tax,
+            broker_fee=broker_fee, quantity=quantity, est_days=est_days_aggressive,
+        )
+        isk_day_premium = self._calc_isk_per_day(
+            price=price_premium, cost_basis=cost_basis, sales_tax=sales_tax,
+            broker_fee=broker_fee, quantity=quantity, est_days=est_days_premium,
+        )
+        margin_aggressive = self._calc_net_margin(price=price_aggressive, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
+        margin_premium = self._calc_net_margin(price=price_premium, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
+
+        return {
+            "aggressive": {
+                "price": float(price_aggressive),
+                "label": "Aggressive — fastest sell",
+                "estimated_sell_days": est_days_aggressive,
+                "isk_per_day": isk_day_aggressive,
+                "net_margin_pct": margin_aggressive,
+            },
+            "target": {
+                "price": float(price_target),
+                "label": "Target — optimal ISK/day",
+                "estimated_sell_days": None,  # shown in main metrics already
+                "isk_per_day": None,
+                "net_margin_pct": None,
+            },
+            "premium": {
+                "price": float(price_premium),
+                "label": premium_label,
+                "estimated_sell_days": est_days_premium,
+                "isk_per_day": isk_day_premium,
+                "net_margin_pct": margin_premium,
+            },
+        }
+
+    # ── Signals ───────────────────────────────────────────────────────────────
 
     def _calc_hold_signal(
         self,
@@ -470,16 +659,12 @@ class PricingSuggestionService:
         quantity: int,
         isk_per_day_advised: float | None,
     ) -> dict[str, Any] | None:
-        """Suggest whether to delay listing when the market trend strongly favours holding."""
         if not market_data.get("has_data") or not hub_price or hub_price <= 0:
             return None
-
         trend_pct = float(market_data.get("trend_pct") or 0)
         if trend_pct <= 5:
             return {"suggested": False, "reason": "Market not trending up significantly"}
 
-        # Linear extrapolation: spread the observed 7d-vs-42w trend over 7 calendar days
-        # trend_pct = ((avg_7d - avg_42w) / avg_42w) * 100 — represents drift over 42 weeks
         daily_rate = trend_pct / (42 * 7)
         price_in_7d = hub_price * (1.0 + daily_rate * 7)
         gain_per_unit = price_in_7d - hub_price
@@ -516,24 +701,22 @@ class PricingSuggestionService:
         price: float,
         quantity: int,
     ) -> dict[str, Any] | None:
-        """Flag if the order is likely to expire before fully selling."""
         if est_days is None:
             return None
         if est_days <= order_duration_days:
             return {"at_risk": False}
-
         unsold_fraction = max(0.0, 1.0 - (order_duration_days / est_days))
         unsold_quantity = max(0, int(quantity * unsold_fraction))
-        relist_cost_estimate = float(price * broker_fee * unsold_quantity)
-
         return {
             "at_risk": True,
             "estimated_sell_days": float(est_days),
             "order_duration_days": order_duration_days,
             "estimated_unsold_quantity": unsold_quantity,
-            "estimated_relist_cost": relist_cost_estimate,
+            "estimated_relist_cost": float(price * broker_fee * unsold_quantity),
             "reason": f"Est. {est_days:.0f}d to sell exceeds {order_duration_days}d order duration",
         }
+
+    # ── Confidence & reasoning ────────────────────────────────────────────────
 
     def _assess_confidence(
         self,
@@ -542,69 +725,42 @@ class PricingSuggestionService:
         volume_data: dict[str, Any],
         cost_basis: float | None = None,
     ) -> str:
-        """Assess confidence in the recommendation."""
         score = 0
-
-        # Cost basis availability
         if cost_basis and cost_basis > 0:
             score += 2
-
-        # Sales history confidence
         sales_confidence = my_sales.get("confidence", "none")
-        if sales_confidence == "high":
-            score += 3
-        elif sales_confidence == "medium":
-            score += 2
-        elif sales_confidence == "low":
-            score += 1
-
-        # Market data completeness
+        score += {"high": 3, "medium": 2, "low": 1}.get(sales_confidence, 0)
         if market_data.get("has_data"):
             records = market_data.get("record_count", 0)
-            if records > 100:
-                score += 3
-            elif records > 30:
-                score += 2
-            elif records > 7:
-                score += 1
-
-        # Volume data
+            score += 3 if records > 100 else 2 if records > 30 else 1 if records > 7 else 0
         if volume_data.get("has_data") and volume_data.get("avg_daily_volume", 0) > 100:
             score += 2
-
-        if score >= 8:
-            return "high"
-        elif score >= 4:
-            return "medium"
-        else:
-            return "low"
+        return "high" if score >= 8 else "medium" if score >= 4 else "low"
 
     def _build_reasoning(self, breakdown: dict[str, Any], confidence: str) -> str:
-        """Build human-readable explanation."""
         components = breakdown.get("components", {})
         parts = []
-
         if "your_cost_basis" in components:
             parts.append("Your cost basis (floor)")
-
         if "your_recent_sales" in components:
-            comp = components["your_recent_sales"]
-            sample = comp.get("sample_size", 0)
-            parts.append(f"Your recent sales ({sample} samples)")
-
+            n = components["your_recent_sales"].get("sample_size", 0)
+            parts.append(f"Your recent sales ({n} samples)")
         if "market_hub_price" in components:
-            parts.append("Current market hub price")
-
+            comp = components["market_hub_price"]
+            dampened = comp.get("volatility_dampened", False)
+            parts.append(f"Hub price{'  (volatility-dampened)' if dampened else ''}")
         if "market_trend" in components:
-            comp = components["market_trend"]
-            trend = comp.get("trend_pct", 0)
-            direction = "rising" if trend > 0 else "falling"
-            parts.append(f"Market {direction} ({trend:+.1f}%)")
-
-        if "liquidity_adjustment" in components:
-            parts.append("Market liquidity adjustment")
+            t = components["market_trend"].get("trend_pct", 0)
+            parts.append(f"Market {'rising' if t > 0 else 'falling'} ({t:+.1f}%)")
+        if "supply_demand" in components:
+            parts.append(components["supply_demand"].get("label", "supply/demand signal"))
+        if "buy_sell_spread" in components:
+            parts.append(components["buy_sell_spread"].get("label", "spread signal"))
 
         reasoning = f"Based on: {', '.join(parts)}. Confidence: {confidence}."
         if breakdown.get("floored_to_break_even"):
-            reasoning += " (Advised price raised to break-even — weighted average did not cover fees.)"
+            reasoning += " (Price raised to break-even — weighted average did not cover fees.)"
+        if breakdown.get("floored_to_target_margin"):
+            m = breakdown.get("min_target_margin_pct", 8)
+            reasoning += f" (Price raised to meet {m}% target margin.)"
         return reasoning

--- a/src/eve_online_industry_tracker/application/market_analysis/pricing_suggestion_service.py
+++ b/src/eve_online_industry_tracker/application/market_analysis/pricing_suggestion_service.py
@@ -7,7 +7,7 @@ from typing import Any
 from sqlalchemy import and_
 from eve_online_industry_tracker.application.industry.sales_history_service import SalesHistoryService
 from eve_online_industry_tracker.application.market_analysis.market_history_service import MarketHistoryService
-from eve_online_industry_tracker.infrastructure.models import CharacterAssetsModel, CharacterModel
+from eve_online_industry_tracker.infrastructure.models import CharacterAssetsModel, CharacterAssetHistoryModel, CharacterModel
 from eve_online_industry_tracker.infrastructure.session_provider import SessionProvider, StateSessionProvider
 
 
@@ -144,7 +144,13 @@ class PricingSuggestionService:
         """Get average acquisition cost and source for items in inventory.
 
         Returns: (cost_basis, acquisition_source, cost_source)
-        where cost_source is 'asset', 'market_order_fallback', or None
+
+        cost_source values:
+          'asset'                — weighted avg from current CharacterAssetsModel rows
+          'asset_history'        — most recent CharacterAssetHistoryModel record
+                                   (used when item is listed on market and absent
+                                   from the current assets snapshot)
+          'market_order_fallback' — neither assets nor history found; order price used
         """
         app_session = self._sessions.app_session()
         try:
@@ -155,42 +161,56 @@ class PricingSuggestionService:
                 )
             ).all()
 
-            if not assets:
-                logging.debug(f"Cost basis: no assets found (char_id={character_id}, type_id={type_id})")
-                if fallback_price and fallback_price > 0:
-                    logging.debug(f"Cost basis: using market order price as fallback ({fallback_price})")
-                    return fallback_price, "market_order_fallback", "market_order_fallback"
-                return None, None, None
+            if assets:
+                total_cost = 0.0
+                total_quantity = 0
+                sources = set()
 
-            total_cost = 0.0
-            total_quantity = 0
-            sources = set()
+                for asset in assets:
+                    cost = asset.acquisition_unit_cost
+                    qty = asset.quantity
+                    if cost and cost > 0 and qty and qty > 0:
+                        total_cost += cost * qty
+                        total_quantity += qty
+                    if asset.acquisition_source:
+                        sources.add(asset.acquisition_source)
 
-            for asset in assets:
-                cost = asset.acquisition_unit_cost
-                qty = asset.quantity
-                if cost and cost > 0 and qty and qty > 0:
-                    total_cost += cost * qty
-                    total_quantity += qty
-                if asset.acquisition_source:
-                    sources.add(asset.acquisition_source)
+                if total_quantity > 0:
+                    avg_cost = total_cost / total_quantity
+                    source = None
+                    if "manufactured" in sources:
+                        source = "manufactured"
+                    elif "bought" in sources or "market" in sources:
+                        source = "bought"
+                    elif sources:
+                        source = list(sources)[0]
 
-            if total_quantity > 0:
-                avg_cost = total_cost / total_quantity
-                source = None
-                if "manufactured" in sources:
-                    source = "manufactured"
-                elif "bought" in sources or "market" in sources:
-                    source = "bought"
-                elif sources:
-                    source = list(sources)[0]
+                    logging.debug(f"Cost basis found: {avg_cost} ({source}), char_id={character_id}, type_id={type_id}")
+                    return avg_cost, source, "asset"
 
-                logging.debug(f"Cost basis found: {avg_cost} ({source}), char_id={character_id}, type_id={type_id}")
-                return avg_cost, source, "asset"
+            # Item is likely listed on market — ESI removes active sell orders from
+            # the assets endpoint. Fall back to the most recent asset history record.
+            logging.debug(f"Cost basis: no current assets with cost (char_id={character_id}, type_id={type_id}), checking history")
+            history_row = (
+                app_session.query(CharacterAssetHistoryModel)
+                .filter(
+                    and_(
+                        CharacterAssetHistoryModel.character_id == character_id,
+                        CharacterAssetHistoryModel.type_id == type_id,
+                        CharacterAssetHistoryModel.acquisition_unit_cost.isnot(None),
+                    )
+                )
+                .order_by(CharacterAssetHistoryModel.observed_at.desc())
+                .first()
+            )
+            if history_row and history_row.acquisition_unit_cost and history_row.acquisition_unit_cost > 0:
+                source = history_row.acquisition_source or "unknown"
+                logging.debug(f"Cost basis from history: {history_row.acquisition_unit_cost} ({source})")
+                return float(history_row.acquisition_unit_cost), source, "asset_history"
 
-            logging.debug(f"Cost basis: found {len(assets)} asset(s) but none with costs, char_id={character_id}, type_id={type_id}")
+            # Last resort: use the order's own price as a rough proxy
             if fallback_price and fallback_price > 0:
-                logging.debug(f"Cost basis: using market order price as fallback for assetless item ({fallback_price})")
+                logging.debug(f"Cost basis: using market order price as fallback ({fallback_price})")
                 return fallback_price, "market_order_fallback", "market_order_fallback"
             return None, None, None
         finally:

--- a/src/eve_online_industry_tracker/application/market_analysis/pricing_suggestion_service.py
+++ b/src/eve_online_industry_tracker/application/market_analysis/pricing_suggestion_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import statistics
+from datetime import datetime
 from typing import Any
 
 from sqlalchemy import and_
@@ -30,8 +32,9 @@ class PricingSuggestionService:
         region_id: int = 10000002,
         quantity: int = 0,
         order_duration_days: int = 90,
+        days_remaining: int | None = None,
     ) -> dict[str, Any]:
-        """Suggest a sell price with detailed breakdown and three-tier price band."""
+        """Suggest a sell price with detailed breakdown, three-tier price band, and urgency signals."""
         my_sales = self._sales_history.suggest_sell_price(character_id=character_id, type_id=type_id)
         market_data = self._market_history.get_price_stats(type_id=type_id, region_id=region_id)
         volume_data = self._market_history.get_volume_stats(type_id=type_id, region_id=region_id)
@@ -41,8 +44,15 @@ class PricingSuggestionService:
         hub_price = self._get_hub_price(type_id=type_id, hub=hub)
         hub_buy_price = self._get_hub_buy_price(type_id=type_id, hub=hub)
         sales_tax, broker_fee = self._get_fees(character_id=character_id)
-        orderbook_levels = self._get_orderbook_levels(type_id=type_id, region_id=region_id)
+        raw_orderbook = self._get_orderbook_levels(type_id=type_id, region_id=region_id)
+        orderbook_levels = self._filter_orderbook_outliers(raw_orderbook)
         min_target_margin = self._get_min_target_margin()
+
+        fill_rate = self._get_fill_rate_velocity(
+            character_id=character_id, type_id=type_id,
+            current_price=current_price, lookback_days=90,
+        )
+        seller_concentration = self._get_seller_concentration(orderbook_levels=orderbook_levels)
 
         breakdown = self._calculate_breakdown(
             my_sales=my_sales,
@@ -65,27 +75,30 @@ class PricingSuggestionService:
             min_target_margin=min_target_margin,
         )
 
-        # Floor 1: break-even — never advise a loss after fees
+        # Floor 1: break-even
         if break_even and advised_price < break_even:
             advised_price = break_even
             breakdown["weighted_price"] = advised_price
             breakdown["floored_to_break_even"] = True
 
-        # Floor 2: minimum target margin — respect configured profit target
+        # Floor 2: minimum target margin
         if min_target_price and advised_price < min_target_price:
             advised_price = min_target_price
             breakdown["weighted_price"] = advised_price
             breakdown["floored_to_target_margin"] = True
             breakdown["min_target_margin_pct"] = round(min_target_margin * 100, 1)
 
+        floor = min_target_price or break_even or advised_price
+
         net_margin_advised = self._calc_net_margin(price=advised_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
         net_margin_current = self._calc_net_margin(price=current_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
-        est_days_advised = self._estimate_sell_days(target_price=advised_price, quantity=quantity, orderbook_levels=orderbook_levels, avg_daily_volume=avg_daily_vol)
-        est_days_current = self._estimate_sell_days(target_price=current_price, quantity=quantity, orderbook_levels=orderbook_levels, avg_daily_volume=avg_daily_vol)
+        est_days_advised = self._estimate_sell_days(target_price=advised_price, quantity=quantity, orderbook_levels=orderbook_levels, avg_daily_volume=avg_daily_vol, fill_rate=fill_rate)
+        est_days_current = self._estimate_sell_days(target_price=current_price, quantity=quantity, orderbook_levels=orderbook_levels, avg_daily_volume=avg_daily_vol, fill_rate=fill_rate)
         isk_per_day_advised = self._calc_isk_per_day(price=advised_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee, quantity=quantity, est_days=est_days_advised)
         isk_per_day_current = self._calc_isk_per_day(price=current_price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee, quantity=quantity, est_days=est_days_current)
         hold_signal = self._calc_hold_signal(market_data=market_data, hub_price=hub_price, quantity=quantity, isk_per_day_advised=isk_per_day_advised)
         relist_risk = self._calc_relist_risk(est_days=est_days_advised, order_duration_days=order_duration_days, broker_fee=broker_fee, price=advised_price, quantity=quantity)
+
         price_band = self._calc_price_band(
             target_price=advised_price,
             min_target_price=min_target_price,
@@ -99,7 +112,36 @@ class PricingSuggestionService:
             broker_fee=broker_fee,
             quantity=quantity,
             avg_daily_vol=avg_daily_vol,
+            fill_rate=fill_rate,
         )
+
+        # Expiry urgency: if the order will likely expire before selling, blend toward aggressive
+        expiry_urgency = False
+        expiry_urgency_detail: dict[str, Any] = {}
+        if days_remaining is not None and days_remaining >= 0 and est_days_advised is not None and est_days_advised > 0:
+            if days_remaining < est_days_advised * 0.5:
+                expiry_urgency = True
+                # urgency_ratio 0.0 = just entered danger zone, 1.0 = expiry tomorrow
+                urgency_ratio = max(0.0, 1.0 - (days_remaining / max(1.0, est_days_advised * 0.5)))
+                blend = min(0.5, urgency_ratio)  # cap at 50% blend toward aggressive
+                aggressive_price = (price_band or {}).get("aggressive", {}).get("price") or advised_price
+                urgency_price = max(floor, advised_price * (1.0 - blend) + aggressive_price * blend)
+                expiry_urgency_detail = {
+                    "days_remaining": int(days_remaining),
+                    "est_days_advised": round(est_days_advised, 1),
+                    "urgency_blend": round(blend, 3),
+                    "urgency_ratio": round(urgency_ratio, 3),
+                    "original_advised": float(advised_price),
+                    "urgency_adjusted_price": float(urgency_price),
+                    "reason": (
+                        f"Order expires in {days_remaining}d but est. {est_days_advised:.0f}d to sell — "
+                        f"advised price moved {blend*100:.0f}% toward aggressive tier."
+                    ),
+                }
+                advised_price = urgency_price
+                breakdown["weighted_price"] = advised_price
+                breakdown["urgency_adjusted"] = True
+                breakdown["urgency_blend"] = round(blend, 3)
 
         return {
             "advised_price": advised_price,
@@ -125,12 +167,16 @@ class PricingSuggestionService:
             "hold_signal": hold_signal,
             "relist_risk": relist_risk,
             "price_band": price_band,
+            "fill_rate_velocity": fill_rate,
+            "seller_concentration": seller_concentration,
+            "expiry_urgency": expiry_urgency,
+            "expiry_urgency_detail": expiry_urgency_detail if expiry_urgency else None,
+            "outlier_levels_removed": len(raw_orderbook) - len(orderbook_levels),
         }
 
     # ── Data retrieval ────────────────────────────────────────────────────────
 
     def _get_hub_price(self, *, type_id: int, hub: str = "jita") -> float | None:
-        """Current best Jita sell price from market pricing service."""
         try:
             svc = getattr(self._state, "market_pricing_service", None)
             if svc is None:
@@ -158,16 +204,6 @@ class PricingSuggestionService:
     def _get_cost_basis(
         self, *, character_id: int, type_id: int, fallback_price: float | None = None
     ) -> tuple[float | None, str | None, str | None]:
-        """Weighted-average acquisition cost for an item.
-
-        Priority:
-          1. Current CharacterAssetsModel rows (item in hangar)
-          2. Most recent CharacterAssetHistoryModel row (item on market — ESI removes
-             active sell orders from the assets snapshot)
-          3. Current order price as last resort (unreliable; triggers warning)
-
-        Returns (cost_basis, acquisition_source, cost_source).
-        """
         app_session = self._sessions.app_session()
         try:
             assets = app_session.query(CharacterAssetsModel).filter(
@@ -223,7 +259,6 @@ class PricingSuggestionService:
                 pass
 
     def _get_fees(self, *, character_id: int) -> tuple[float, float]:
-        """(sales_tax_fraction, broker_fee_fraction) — falls back to EVE defaults."""
         try:
             app_session = self._sessions.app_session()
             try:
@@ -241,7 +276,6 @@ class PricingSuggestionService:
         return 0.075, 0.03
 
     def _get_orderbook_levels(self, *, type_id: int, region_id: int = 10000002) -> list[list[float]]:
-        """Cached Jita 4-4 sell orderbook [[price, volume], ...] sorted ascending."""
         try:
             from eve_online_industry_tracker.infrastructure.persistence.market_orderbook_cache_repo import get_cached_orderbook_levels
             app_session = self._sessions.app_session()
@@ -261,7 +295,6 @@ class PricingSuggestionService:
         return []
 
     def _get_min_target_margin(self) -> float:
-        """Minimum acceptable net profit margin (fraction). Configurable via cfg_manager."""
         try:
             cfg_manager = getattr(self._state, "cfg_manager", None)
             if cfg_manager:
@@ -271,7 +304,135 @@ class PricingSuggestionService:
                     return max(0.0, min(0.50, float(advisory_cfg["min_target_margin_pct"]) / 100))
         except Exception:
             pass
-        return 0.08  # 8 % default
+        return 0.08
+
+    # ── Orderbook preprocessing ───────────────────────────────────────────────
+
+    def _filter_orderbook_outliers(self, levels: list[list[float]]) -> list[list[float]]:
+        """Remove manipulation walls using IQR fencing on the price axis.
+
+        A single large-volume order at an extreme price can inflate days_of_supply
+        and make the market appear oversupplied when it isn't. Only upper outliers
+        are removed — lower prices are legitimate undercuts.
+        """
+        if len(levels) < 4:
+            return levels
+        prices = [float(lv[0]) for lv in levels]
+        qs = statistics.quantiles(prices, n=4)  # [Q1, median, Q3]
+        q1, q3 = qs[0], qs[2]
+        iqr = q3 - q1
+        if iqr <= 0:
+            return levels
+        upper_fence = q3 + 2.0 * iqr
+        filtered = [lv for lv in levels if float(lv[0]) <= upper_fence]
+        return filtered if len(filtered) >= 2 else levels[:2]
+
+    # ── Market microstructure signals ─────────────────────────────────────────
+
+    def _get_seller_concentration(self, *, orderbook_levels: list[list[float]]) -> dict[str, Any]:
+        """Detect sniper risk by measuring how concentrated the front of the queue is.
+
+        In EVE a single seller can instantly reset the queue by repricing. We use
+        front-level volume fraction as a proxy: if one or two levels own >60-80%
+        of visible supply, the advised aggressive undercut may not last.
+        """
+        if not orderbook_levels:
+            return {"sniper_risk": False, "risk_label": "No orderbook data", "note": ""}
+
+        total_vol = sum(int(lv[1]) for lv in orderbook_levels)
+        if total_vol == 0:
+            return {"sniper_risk": False, "risk_label": "Empty orderbook", "note": ""}
+
+        front_1_vol = int(orderbook_levels[0][1])
+        front_2_vol = sum(int(lv[1]) for lv in orderbook_levels[:2])
+        front_1_fraction = front_1_vol / total_vol
+        front_2_fraction = front_2_vol / total_vol
+        num_levels = len(orderbook_levels)
+
+        sniper_risk = (front_1_fraction > 0.60 and num_levels >= 2) or \
+                      (front_2_fraction > 0.80 and num_levels >= 3)
+
+        if sniper_risk:
+            risk_label = "Sniper risk"
+            note = "Dominant seller controls front of queue — undercutting by 0.01 ISK may not stick"
+        elif front_2_fraction > 0.60:
+            risk_label = "Moderate concentration"
+            note = "A few large sell walls dominate; check how often they reprice"
+        else:
+            risk_label = "Distributed"
+            note = "Multiple sellers at varied levels — normal market"
+
+        return {
+            "sniper_risk": sniper_risk,
+            "front_1_volume_pct": round(front_1_fraction * 100, 1),
+            "front_2_volume_pct": round(front_2_fraction * 100, 1),
+            "num_price_levels": num_levels,
+            "total_visible_volume": int(total_vol),
+            "risk_label": risk_label,
+            "note": note,
+        }
+
+    # ── Wallet fill-rate velocity ─────────────────────────────────────────────
+
+    def _get_fill_rate_velocity(
+        self,
+        *,
+        character_id: int,
+        type_id: int,
+        current_price: float,
+        lookback_days: int = 90,
+    ) -> dict[str, Any] | None:
+        """Estimate actual daily sell velocity from wallet transaction history.
+
+        Uses your own completed sales rather than the market-wide orderbook
+        heuristic, reflecting your real historical throughput at this station.
+        A simple price-elasticity factor adjusts for the difference between your
+        median historical sell price and the current target price.
+        """
+        history = self._sales_history.get_sold_history(
+            character_id=character_id, type_id=type_id, days=lookback_days
+        )
+        if len(history) < 2:
+            return None
+
+        total_qty = sum(tx["quantity"] for tx in history)
+        if total_qty <= 0:
+            return None
+
+        # Infer actual date span (not just the lookback window)
+        dates = [tx["date"] for tx in history if tx["date"]]
+        try:
+            oldest = datetime.fromisoformat(str(dates[-1]).replace("Z", "+00:00"))
+            newest = datetime.fromisoformat(str(dates[0]).replace("Z", "+00:00"))
+            day_span = max(1.0, float((newest - oldest).days + 1))
+        except Exception:
+            day_span = float(lookback_days)
+
+        daily_velocity_raw = total_qty / day_span
+
+        # Price-elasticity: each 1% above median historical sell price
+        # reduces expected velocity by ~0.5% (conservative linear approximation)
+        prices = [tx["unit_price"] for tx in history if tx["unit_price"] > 0]
+        median_price = float(statistics.median(prices)) if prices else current_price
+        if median_price > 0 and current_price > 0:
+            premium_pct = (current_price - median_price) / median_price * 100
+            elasticity_factor = max(0.20, 1.0 - premium_pct * 0.005)
+        else:
+            elasticity_factor = 1.0
+
+        adjusted_velocity = max(0.001, daily_velocity_raw * elasticity_factor)
+        transaction_count = len(history)
+        confidence = "high" if transaction_count >= 10 else "medium" if transaction_count >= 4 else "low"
+
+        return {
+            "daily_velocity_raw": round(daily_velocity_raw, 3),
+            "daily_velocity_adjusted": round(adjusted_velocity, 4),
+            "median_historical_price": float(median_price),
+            "transaction_count": transaction_count,
+            "day_span": int(day_span),
+            "confidence": confidence,
+            "elasticity_factor": round(elasticity_factor, 3),
+        }
 
     # ── Core price calculation ────────────────────────────────────────────────
 
@@ -287,17 +448,9 @@ class PricingSuggestionService:
         current_price: float,
         orderbook_levels: list[list[float]],
     ) -> dict[str, Any]:
-        """Build weighted-price components.
-
-        Improvements vs original:
-          B — Hub price weight dampened by volatility (high vol = less hub anchoring)
-          A — Days-of-supply replaces the old three-bucket liquidity adjustment
-          C — Buy-sell spread added as a demand-pressure signal
-        """
         components: dict[str, Any] = {}
         volatility_pct = float(market_data.get("volatility_pct") or 0) if market_data.get("has_data") else 0.0
 
-        # Component 0: Your cost basis (15% weight) — soft floor
         if cost_basis and cost_basis > 0:
             components["your_cost_basis"] = {
                 "value": float(cost_basis * 1.05),
@@ -306,7 +459,6 @@ class PricingSuggestionService:
                 "margin_pct": 5,
             }
 
-        # Component 1: Your recent sales median (20% weight)
         my_sales_price = my_sales.get("suggested_price")
         if my_sales_price and my_sales_price > 0:
             components["your_recent_sales"] = {
@@ -316,8 +468,6 @@ class PricingSuggestionService:
                 "confidence": my_sales.get("confidence", "none"),
             }
 
-        # Component 2: Hub price — B: weight dampened by volatility
-        # High volatility → hub snapshot is less reliable → redistribute to other signals
         if hub_price and hub_price > 0:
             hub_weight = max(0.15, 0.35 / (1.0 + volatility_pct / 100.0))
             components["market_hub_price"] = {
@@ -327,10 +477,8 @@ class PricingSuggestionService:
                 "volatility_dampened": volatility_pct > 10,
             }
 
-        # Component 3: Market trend (15% weight)
         if market_data.get("has_data"):
             avg_42w = market_data.get("avg_42w") or 0
-            avg_7d = market_data.get("avg_7d") or 0
             trend_pct = market_data.get("trend_pct") or 0
             adjustment_factor = 1.0 + (trend_pct / 100.0 * 0.5)
             trend_price = avg_42w * adjustment_factor if avg_42w > 0 else None
@@ -340,10 +488,9 @@ class PricingSuggestionService:
                     "weight": 0.15,
                     "trend_pct": trend_pct,
                     "avg_42w": float(avg_42w),
-                    "avg_7d": float(avg_7d),
+                    "avg_7d": float(market_data.get("avg_7d") or 0),
                 }
 
-        # Component 4: A — Days-of-supply (replaces three-bucket liquidity adjustment)
         supply_signal = self._calc_supply_demand_signal(
             orderbook_levels=orderbook_levels,
             volume_data=volume_data,
@@ -353,7 +500,6 @@ class PricingSuggestionService:
         if supply_signal:
             components["supply_demand"] = supply_signal
 
-        # Component 5: C — Buy-sell spread demand pressure (if buy price available)
         spread_signal = self._calc_buy_sell_spread_signal(
             hub_sell_price=hub_price,
             hub_buy_price=hub_buy_price,
@@ -361,7 +507,6 @@ class PricingSuggestionService:
         if spread_signal:
             components["buy_sell_spread"] = spread_signal
 
-        # Weighted price — renormalise across present components
         total_weight = sum(c.get("weight", 0) for c in components.values())
         if total_weight > 0:
             weighted_price = sum(
@@ -370,7 +515,6 @@ class PricingSuggestionService:
         else:
             weighted_price = current_price
 
-        # Soft floor: cost + 5% (fee-aware hard floors applied in suggest_price)
         if cost_basis and cost_basis > 0:
             weighted_price = max(weighted_price, cost_basis * 1.05)
 
@@ -388,13 +532,6 @@ class PricingSuggestionService:
         hub_price: float | None,
         current_price: float,
     ) -> dict[str, Any] | None:
-        """A — Days-of-supply signal replacing the old liquidity bucket.
-
-        days_of_supply = total sell volume in orderbook / avg daily volume
-          > 30 days → oversupplied  → price conservatively
-          7–30 days → balanced      → price at reference
-          < 7 days  → undersupplied → can hold above reference
-        """
         if not volume_data.get("has_data"):
             return None
         avg_daily_volume = float(volume_data.get("avg_daily_volume") or 0)
@@ -433,12 +570,6 @@ class PricingSuggestionService:
         hub_sell_price: float | None,
         hub_buy_price: float | None,
     ) -> dict[str, Any] | None:
-        """C — Buy-sell spread as a demand pressure signal.
-
-        Tight spread (<5%)  → buyers are close to the ask → demand is strong
-        Normal spread (5-25%) → neutral
-        Wide spread (>25%)  → thin demand → price more conservatively
-        """
         if not hub_sell_price or hub_sell_price <= 0 or not hub_buy_price or hub_buy_price <= 0:
             return None
         if hub_buy_price >= hub_sell_price:
@@ -447,11 +578,9 @@ class PricingSuggestionService:
         spread_pct = (hub_sell_price - hub_buy_price) / hub_sell_price * 100
 
         if spread_pct < 5:
-            # Tight: buyers close to ask — slight premium possible
             signal_price = hub_sell_price * 1.01
             label = f"tight spread ({spread_pct:.1f}%) — strong demand"
         elif spread_pct > 25:
-            # Wide: thin demand — approach midpoint pricing
             midpoint = (hub_sell_price + hub_buy_price) / 2
             signal_price = midpoint
             label = f"wide spread ({spread_pct:.1f}%) — thin demand, price conservatively"
@@ -486,7 +615,6 @@ class PricingSuggestionService:
         broker_fee: float,
         min_target_margin: float,
     ) -> float | None:
-        """Minimum list price to achieve the configured profit margin after fees."""
         if not cost_basis or cost_basis <= 0 or min_target_margin <= 0:
             return None
         net_rate = 1.0 - min_target_margin - sales_tax - broker_fee
@@ -526,19 +654,37 @@ class PricingSuggestionService:
         quantity: int,
         orderbook_levels: list[list[float]],
         avg_daily_volume: float,
+        fill_rate: dict[str, Any] | None = None,
     ) -> float | None:
-        if not quantity or quantity <= 0 or not avg_daily_volume or avg_daily_volume <= 0:
-            return None
-        volume_ahead = sum(int(vol) for price, vol in orderbook_levels if price < target_price)
-        volume_at_level = sum(
-            int(vol) for price, vol in orderbook_levels
-            if target_price <= price <= target_price * 1.001
-        )
-        days_until_front = volume_ahead / avg_daily_volume
-        total_at_level = quantity + volume_at_level
-        capture_rate = min(0.50, max(0.05, quantity / total_at_level))
-        days_for_our_units = quantity / (avg_daily_volume * capture_rate)
-        return float(days_until_front + days_for_our_units)
+        """Blend orderbook queue heuristic with wallet fill-rate history.
+
+        Fill-rate weight by confidence:
+          high (≥10 txns)   → 65% fill-rate, 35% heuristic
+          medium (4-9 txns) → 45% fill-rate, 55% heuristic
+          low (2-3 txns)    → 25% fill-rate, 75% heuristic
+        """
+        heuristic_days: float | None = None
+        if quantity > 0 and avg_daily_volume > 0:
+            volume_ahead = sum(int(vol) for price, vol in orderbook_levels if price < target_price)
+            volume_at_level = sum(
+                int(vol) for price, vol in orderbook_levels
+                if target_price <= price <= target_price * 1.001
+            )
+            days_until_front = volume_ahead / avg_daily_volume
+            total_at_level = quantity + volume_at_level
+            capture_rate = min(0.50, max(0.05, quantity / total_at_level)) if total_at_level > 0 else 0.35
+            days_for_our_units = quantity / (avg_daily_volume * capture_rate)
+            heuristic_days = float(days_until_front + days_for_our_units)
+
+        if fill_rate and fill_rate.get("daily_velocity_adjusted", 0) > 0 and quantity > 0:
+            fill_days = float(quantity / fill_rate["daily_velocity_adjusted"])
+            confidence = fill_rate.get("confidence", "low")
+            fill_weight = {"high": 0.65, "medium": 0.45, "low": 0.25}.get(confidence, 0.25)
+            if heuristic_days is not None:
+                return float(heuristic_days * (1.0 - fill_weight) + fill_days * fill_weight)
+            return fill_days
+
+        return heuristic_days
 
     # ── Price band ────────────────────────────────────────────────────────────
 
@@ -557,43 +703,24 @@ class PricingSuggestionService:
         broker_fee: float,
         quantity: int,
         avg_daily_vol: float,
+        fill_rate: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """F — Three-tier price band: aggressive / target / premium.
-
-        Aggressive — fastest sell, at or above minimum target margin floor.
-          • If our current price is already at or below the cheapest queue entry
-            (we're at the front), aggressive = target (no need to undercut further).
-          • Otherwise, undercut the cheapest competing sell by 0.01 ISK, but never
-            below the minimum target margin price.
-
-        Target — optimal ISK/day; the current advised price after all floors.
-
-        Premium — best margin, slower sell.
-          • Projects the market trend forward 14 days.
-          • Capped at hub_price × 1.25 to avoid absurd suggestions.
-          • Only offered when trend_pct > 2 %; otherwise equals target.
-        """
         floor = min_target_price or break_even_price or target_price
 
-        # Aggressive
         if orderbook_levels:
             cheapest_competing = orderbook_levels[0][0]
             if current_price <= cheapest_competing:
-                # We're already at the front — don't go lower
                 price_aggressive = max(floor, current_price)
             else:
                 price_aggressive = max(floor, cheapest_competing - 0.01)
         else:
             price_aggressive = floor
 
-        # Aggressive is always ≤ target (it's the fast-sell option, not a premium)
         price_aggressive = min(price_aggressive, target_price)
         price_aggressive = max(price_aggressive, floor)
 
-        # Target (= advised price)
         price_target = target_price
 
-        # Premium
         trend_pct = float(market_data.get("trend_pct") or 0) if market_data.get("has_data") else 0.0
         if hub_price and hub_price > 0 and trend_pct > 2:
             daily_rate = trend_pct / (42 * 7)
@@ -605,48 +732,23 @@ class PricingSuggestionService:
             price_premium = price_target
             premium_label = "Market not trending up — same as target"
 
-        # Compute sell days and ISK/day for aggressive and premium for UI context
-        est_days_aggressive = self._estimate_sell_days(
-            target_price=price_aggressive, quantity=quantity,
-            orderbook_levels=orderbook_levels, avg_daily_volume=avg_daily_vol,
-        )
-        est_days_premium = self._estimate_sell_days(
-            target_price=price_premium, quantity=quantity,
-            orderbook_levels=orderbook_levels, avg_daily_volume=avg_daily_vol,
-        )
-        isk_day_aggressive = self._calc_isk_per_day(
-            price=price_aggressive, cost_basis=cost_basis, sales_tax=sales_tax,
-            broker_fee=broker_fee, quantity=quantity, est_days=est_days_aggressive,
-        )
-        isk_day_premium = self._calc_isk_per_day(
-            price=price_premium, cost_basis=cost_basis, sales_tax=sales_tax,
-            broker_fee=broker_fee, quantity=quantity, est_days=est_days_premium,
-        )
-        margin_aggressive = self._calc_net_margin(price=price_aggressive, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
-        margin_premium = self._calc_net_margin(price=price_premium, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
+        def _tier_metrics(price: float) -> dict[str, Any]:
+            est_d = self._estimate_sell_days(
+                target_price=price, quantity=quantity,
+                orderbook_levels=orderbook_levels, avg_daily_volume=avg_daily_vol,
+                fill_rate=fill_rate,
+            )
+            isk_d = self._calc_isk_per_day(
+                price=price, cost_basis=cost_basis, sales_tax=sales_tax,
+                broker_fee=broker_fee, quantity=quantity, est_days=est_d,
+            )
+            margin = self._calc_net_margin(price=price, cost_basis=cost_basis, sales_tax=sales_tax, broker_fee=broker_fee)
+            return {"estimated_sell_days": est_d, "isk_per_day": isk_d, "net_margin_pct": margin}
 
         return {
-            "aggressive": {
-                "price": float(price_aggressive),
-                "label": "Aggressive — fastest sell",
-                "estimated_sell_days": est_days_aggressive,
-                "isk_per_day": isk_day_aggressive,
-                "net_margin_pct": margin_aggressive,
-            },
-            "target": {
-                "price": float(price_target),
-                "label": "Target — optimal ISK/day",
-                "estimated_sell_days": None,  # shown in main metrics already
-                "isk_per_day": None,
-                "net_margin_pct": None,
-            },
-            "premium": {
-                "price": float(price_premium),
-                "label": premium_label,
-                "estimated_sell_days": est_days_premium,
-                "isk_per_day": isk_day_premium,
-                "net_margin_pct": margin_premium,
-            },
+            "aggressive": {"price": float(price_aggressive), "label": "Aggressive — fastest sell", **_tier_metrics(price_aggressive)},
+            "target": {"price": float(price_target), "label": "Target — optimal ISK/day", "estimated_sell_days": None, "isk_per_day": None, "net_margin_pct": None},
+            "premium": {"price": float(price_premium), "label": premium_label, **_tier_metrics(price_premium)},
         }
 
     # ── Signals ───────────────────────────────────────────────────────────────
@@ -746,8 +848,7 @@ class PricingSuggestionService:
             n = components["your_recent_sales"].get("sample_size", 0)
             parts.append(f"Your recent sales ({n} samples)")
         if "market_hub_price" in components:
-            comp = components["market_hub_price"]
-            dampened = comp.get("volatility_dampened", False)
+            dampened = components["market_hub_price"].get("volatility_dampened", False)
             parts.append(f"Hub price{'  (volatility-dampened)' if dampened else ''}")
         if "market_trend" in components:
             t = components["market_trend"].get("trend_pct", 0)
@@ -763,4 +864,7 @@ class PricingSuggestionService:
         if breakdown.get("floored_to_target_margin"):
             m = breakdown.get("min_target_margin_pct", 8)
             reasoning += f" (Price raised to meet {m}% target margin.)"
+        if breakdown.get("urgency_adjusted"):
+            blend_pct = round((breakdown.get("urgency_blend", 0)) * 100)
+            reasoning += f" (Expiry urgency: price moved {blend_pct}% toward aggressive tier.)"
         return reasoning

--- a/src/streamlit_ui/components/aggrid_formatters.py
+++ b/src/streamlit_ui/components/aggrid_formatters.py
@@ -127,6 +127,41 @@ def js_icon_cell_renderer(*, JsCode: Any, size_px: int = 24) -> Any:
     )
 
 
+def js_margin_pct_cell_style(*, JsCode: Any) -> Any:
+    """Color-coded cell style for profit margin % columns.
+
+    negative  → red background  (loss)
+    0–5 %     → amber           (thin / below typical target)
+    5–15 %    → neutral
+    > 15 %    → green           (healthy margin)
+    """
+    if JsCode is None:
+        return None
+    return JsCode(
+        """
+        function(params) {
+            var style = {textAlign: 'right'};
+            var v = params.value;
+            if (v === null || v === undefined || v === '') return style;
+            var n = Number(v);
+            if (isNaN(n)) return style;
+            if (n < 0) {
+                style.backgroundColor = '#c0392b';
+                style.color = '#ffffff';
+                style.fontWeight = 'bold';
+            } else if (n < 5) {
+                style.backgroundColor = '#e67e22';
+                style.color = '#ffffff';
+            } else if (n >= 15) {
+                style.color = '#27ae60';
+                style.fontWeight = '600';
+            }
+            return style;
+        }
+        """
+    )
+
+
 def js_flag_text_style(
     *,
     JsCode: Any,

--- a/src/streamlit_ui/pages/marketorders.py
+++ b/src/streamlit_ui/pages/marketorders.py
@@ -215,7 +215,7 @@ def _render_buy_stats_box(df: pd.DataFrame) -> None:
 
 # ── Grid row builders ─────────────────────────────────────────────────────────
 
-def _build_order_rows(all_orders: list[dict]) -> tuple[list[dict], list[dict]]:
+def _build_order_rows(all_orders: list[dict], *, priority_map: dict | None = None) -> tuple[list[dict], list[dict]]:
     sell_orders: list[dict] = []
     buy_orders: list[dict] = []
     for order in all_orders:
@@ -253,6 +253,10 @@ def _build_order_rows(all_orders: list[dict]) -> tuple[list[dict], list[dict]]:
                 sell_order["Margin % (Current)"] = round(float(order["net_margin_pct_current"]), 1)
             if order.get("net_margin_pct_advised") is not None:
                 sell_order["Margin % (Advised)"] = round(float(order["net_margin_pct_advised"]), 1)
+            # Relist Priority column
+            if priority_map is not None:
+                key = (order.get("type_name", ""), float(order.get("price") or 0), order.get("station", ""))
+                sell_order["Relist Priority"] = priority_map.get(key, "")
             # Location always last
             sell_order.update(location)
             sell_orders.append(sell_order)
@@ -318,6 +322,20 @@ def _render_orders_grid(
             cellStyle=right,
             minWidth=90,
         )
+
+    if "Relist Priority" in df.columns:
+        priority_style = runtime.js_code(
+            """
+            function(params) {
+                var v = params.value;
+                if (v === 'High')   return {color: '#ef4444', fontWeight: '700', textAlign: 'center'};
+                if (v === 'Medium') return {color: '#f59e0b', fontWeight: '600', textAlign: 'center'};
+                if (v === 'Low')    return {color: '#9ca3af', textAlign: 'center'};
+                return {textAlign: 'center'};
+            }
+            """
+        )
+        gb.configure_column("Relist Priority", cellStyle=priority_style, minWidth=100, maxWidth=130)
 
     # Cap location columns so they don't dominate the layout
     for col, max_w in (("Station", 220), ("Region", 160), ("Range", 90)):
@@ -551,8 +569,18 @@ def render():
         st.error(f"Error fetching market orders: {str(e)}")
         return
 
+    # Build Relist Priority map: (type_name, price, station) → "High" / "Medium" / "Low" / ""
+    sell_raw_all = [o for o in all_orders if not o.get("is_buy_order")]
+    sell_raw_sorted = sorted(sell_raw_all, key=lambda o: o.get("reprice_priority_score", 0), reverse=True)
+    priority_map: dict = {}
+    for rank, o in enumerate(sell_raw_sorted, start=1):
+        score = o.get("reprice_priority_score", 0)
+        label = "" if score <= 0 else "High" if rank <= 3 else "Medium" if rank <= 10 else "Low"
+        key = (o.get("type_name", ""), float(o.get("price") or 0), o.get("station", ""))
+        priority_map[key] = label
+
     selected_owner = "All"
-    sell_orders, buy_orders = _build_order_rows(all_orders)
+    sell_orders, buy_orders = _build_order_rows(all_orders, priority_map=priority_map)
 
     if sell_orders:
         df = pd.DataFrame(sell_orders)
@@ -579,16 +607,6 @@ def render():
             st.write("")
 
         st.subheader("Selling")
-
-        # Negative-margin warning
-        if "Margin % (Current)" in df.columns:
-            loss_rows = df[df["Margin % (Current)"] < 0]
-            if not loss_rows.empty:
-                loss_names = ", ".join(loss_rows["Type"].tolist())
-                st.error(
-                    f"**{len(loss_rows)} order(s) are currently priced below break-even** (loss after fees): "
-                    f"{loss_names}. Consider relisting at or above the Advised Price."
-                )
 
         # Stats box — computed from the filtered raw enriched orders
         sell_raw_filtered = [
@@ -622,57 +640,6 @@ def render():
         _render_orders_grid(df_buy, runtime=runtime, img_renderer=img_renderer, isk_cols=["Price", "Total Price", "Price Difference", "Escrow Remaining"], min_volume=True, key="market_orders_buy")
     else:
         st.info("No market buy orders found.")
-
-    # Repricing priority queue
-    if sell_orders:
-        priority_orders = sorted(
-            [o for o in all_orders if not o.get("is_buy_order") and o.get("reprice_priority_score", 0) > 0],
-            key=lambda o: o.get("reprice_priority_score", 0),
-            reverse=True,
-        )
-        if priority_orders:
-            st.divider()
-            st.subheader("🔧 Repricing Priority Queue")
-            st.caption("Orders ranked by urgency — fix these first.")
-            for rank, o in enumerate(priority_orders[:10], start=1):
-                score = o.get("reprice_priority_score", 0)
-                name = o.get("type_name", "Unknown")
-                cur = float(o.get("price") or 0)
-                adv = float(o.get("advised_price") or cur)
-                margin_cur = o.get("net_margin_pct_current")
-                isk_adv = o.get("isk_per_day_advised")
-                isk_cur = o.get("isk_per_day_current")
-
-                flags = []
-                if (margin_cur or 0) < 0:
-                    flags.append("❌ below break-even")
-                if o.get("expiry_urgency"):
-                    detail = o.get("expiry_urgency_detail") or {}
-                    days_rem = detail.get("days_remaining")
-                    est_sell = detail.get("est_days_advised")
-                    flags.append(
-                        f"⏰ expires in {days_rem}d (est. {est_sell:.0f}d to sell)"
-                        if days_rem is not None and est_sell is not None else "⏰ expiry urgency"
-                    )
-                if (o.get("relist_risk") or {}).get("at_risk"):
-                    flags.append("🔁 relist risk")
-                if adv < cur:
-                    diff_pct = (cur - adv) / cur * 100
-                    flags.append(f"📉 {diff_pct:.1f}% above advised")
-
-                isk_gain = ""
-                if isk_adv and isk_cur and isk_adv > isk_cur:
-                    isk_gain = f"  ·  +{format_isk_short(isk_adv - isk_cur)}/day if repriced"
-
-                flag_str = "  ·  ".join(flags) if flags else ""
-                st.write(
-                    f"**#{rank}** &nbsp; {name} &nbsp; (score: {score:.0f}) &nbsp; "
-                    f"{format_isk_short(cur)} → **{format_isk_short(adv)}**"
-                    + (f"  ·  margin: {margin_cur:.1f}%" if margin_cur is not None else ""),
-                    unsafe_allow_html=True,
-                )
-                if flag_str or isk_gain:
-                    st.caption(f"{flag_str}{isk_gain}")
 
     # Pricing analysis panel
     if sell_orders:

--- a/src/streamlit_ui/pages/marketorders.py
+++ b/src/streamlit_ui/pages/marketorders.py
@@ -11,20 +11,17 @@ from streamlit_ui.components.webpage_ui import AgGridRuntime, aggrid_height, req
 def _rerun() -> None:
     st.rerun()
 
+
 def get_item_image_url(order):
-    """Get the image URL for a single order item."""
     type_id = order.get("type_id")
     type_category = order.get("type_category_name", "")
     is_bpc = order.get("is_blueprint_copy", False)
-
-    # Determine image variation
     if type_category == "Blueprint":
         variation = "bpc" if is_bpc else "bp"
     elif type_category == "Permanent SKIN":
         variation = "skins"
     else:
         variation = "icon"
-
     return build_item_image_url(
         type_id=type_id,
         type_category_name=type_category,
@@ -33,11 +30,197 @@ def get_item_image_url(order):
     )
 
 
+# ── Stat card grid (same pattern as Realized Profit page) ────────────────────
+
+def _render_stat_card_grid(cards: list[tuple[str, str]]) -> None:
+    st.markdown(
+        """
+        <style>
+        .mo-stat-tile {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+            gap: 0;
+            border: 1px solid rgba(255,255,255,0.10);
+            border-radius: 12px;
+            overflow: hidden;
+            background: rgba(255,255,255,0.02);
+        }
+        .mo-stat-card {
+            padding: 12px 14px;
+            min-height: 70px;
+            position: relative;
+        }
+        .mo-stat-card:not(:last-child)::after {
+            content: "";
+            position: absolute;
+            top: 14px;
+            right: 0;
+            width: 1px;
+            height: calc(100% - 28px);
+            background: rgba(255,255,255,0.10);
+        }
+        .mo-stat-label {
+            color: #d4d4d8;
+            font-size: 0.78rem;
+            font-weight: 600;
+            line-height: 1.15;
+            margin-bottom: 8px;
+        }
+        .mo-stat-value {
+            font-size: 1.3rem;
+            font-weight: 700;
+            line-height: 1.0;
+            color: #f4f4f5;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+    cards_html = "".join(
+        f"<div class='mo-stat-card'>"
+        f"<div class='mo-stat-label'>{label}</div>"
+        f"<div class='mo-stat-value'>{value}</div>"
+        f"</div>"
+        for label, value in cards
+    )
+    st.markdown(f"<div class='mo-stat-tile'>{cards_html}</div>", unsafe_allow_html=True)
+
+
+def _colored(value: str, *, color: str) -> str:
+    return f"<span style='color:{color}'>{value}</span>"
+
+
+# ── Summary stats computation ─────────────────────────────────────────────────
+
+def _compute_sell_stats(orders: list[dict]) -> dict:
+    count = len(orders)
+    total_listed = sum(float(o.get("total_price") or 0) for o in orders)
+
+    # Est. profit at current price: total_price × net_margin% / 100
+    # (net_margin = (net_proceeds - cost) / price × 100, so cost-profit = price × qty × margin/100 = total_price × margin/100)
+    profit_cur_parts = [
+        float(o.get("total_price") or 0) * float(o["net_margin_pct_current"]) / 100
+        for o in orders
+        if o.get("net_margin_pct_current") is not None and o.get("total_price")
+    ]
+    est_profit_current = sum(profit_cur_parts) if profit_cur_parts else None
+
+    # Est. profit at advised price: advised_price × volume_remain × margin_adv% / 100
+    profit_adv_parts = []
+    for o in orders:
+        if (
+            o.get("advised_price") and
+            o.get("net_margin_pct_advised") is not None and
+            o.get("total_price") and
+            float(o.get("price") or 0) > 0
+        ):
+            vol_remain = float(o["total_price"]) / float(o["price"])
+            adv_total = float(o["advised_price"]) * vol_remain
+            profit_adv_parts.append(adv_total * float(o["net_margin_pct_advised"]) / 100)
+    est_profit_advised = sum(profit_adv_parts) if profit_adv_parts else None
+
+    # ISK/day totals
+    isk_day_cur = [float(o["isk_per_day_current"]) for o in orders if o.get("isk_per_day_current") is not None]
+    isk_day_adv = [float(o["isk_per_day_advised"]) for o in orders if o.get("isk_per_day_advised") is not None]
+    total_isk_day_current = sum(isk_day_cur) if isk_day_cur else None
+    total_isk_day_advised = sum(isk_day_adv) if isk_day_adv else None
+
+    # Weighted-average margin at current price
+    margin_w = [
+        (float(o["net_margin_pct_current"]), float(o.get("total_price") or 0))
+        for o in orders
+        if o.get("net_margin_pct_current") is not None and o.get("total_price")
+    ]
+    avg_margin_current: float | None = None
+    if margin_w:
+        total_w = sum(w for _, w in margin_w)
+        avg_margin_current = sum(m * w for m, w in margin_w) / total_w if total_w > 0 else None
+
+    below_breakeven = sum(1 for o in orders if (o.get("net_margin_pct_current") or 0) < 0)
+
+    return {
+        "count": count,
+        "total_listed": total_listed,
+        "est_profit_current": est_profit_current,
+        "est_profit_advised": est_profit_advised,
+        "total_isk_day_current": total_isk_day_current,
+        "total_isk_day_advised": total_isk_day_advised,
+        "avg_margin_current": avg_margin_current,
+        "below_breakeven": below_breakeven,
+    }
+
+
+def _render_sell_stats_box(stats: dict) -> None:
+    profit_color_cur = "#27ae60" if (stats["est_profit_current"] or 0) >= 0 else "#c0392b"
+    profit_color_adv = "#27ae60" if (stats["est_profit_advised"] or 0) >= 0 else "#c0392b"
+    margin_color = (
+        "#c0392b" if (stats["avg_margin_current"] or 0) < 0
+        else "#e67e22" if (stats["avg_margin_current"] or 0) < 5
+        else "#27ae60" if (stats["avg_margin_current"] or 0) >= 15
+        else "#f4f4f5"
+    )
+    risk_color = "#c0392b" if stats["below_breakeven"] > 0 else "#27ae60"
+
+    left_cards = [
+        ("Active Orders", str(stats["count"])),
+        ("Total Listed ISK", format_isk_short(stats["total_listed"])),
+        (
+            "Avg Margin % (Current)",
+            _colored(f"{stats['avg_margin_current']:.1f}%", color=margin_color)
+            if stats["avg_margin_current"] is not None else "—",
+        ),
+        (
+            "Orders at Risk",
+            _colored(str(stats["below_breakeven"]), color=risk_color),
+        ),
+    ]
+    right_cards = [
+        (
+            "Est. Profit (Current)",
+            _colored(format_isk_short(stats["est_profit_current"]), color=profit_color_cur)
+            if stats["est_profit_current"] is not None else "—",
+        ),
+        (
+            "Est. Profit (Advised)",
+            _colored(format_isk_short(stats["est_profit_advised"]), color=profit_color_adv)
+            if stats["est_profit_advised"] is not None else "—",
+        ),
+        (
+            "Est. ISK/day (Current)",
+            format_isk_short(stats["total_isk_day_current"])
+            if stats["total_isk_day_current"] is not None else "—",
+        ),
+        (
+            "Est. ISK/day (Advised)",
+            format_isk_short(stats["total_isk_day_advised"])
+            if stats["total_isk_day_advised"] is not None else "—",
+        ),
+    ]
+
+    col_l, col_r = st.columns([4, 6])
+    with col_l:
+        _render_stat_card_grid(left_cards)
+    with col_r:
+        _render_stat_card_grid(right_cards)
+
+
+def _render_buy_stats_box(df: pd.DataFrame) -> None:
+    cards = [
+        ("Active Buy Orders", str(len(df))),
+        ("Total Buy Value", format_isk_short(df["Total Price"].sum())),
+        ("Total Escrow", format_isk_short(df["Escrow Remaining"].sum())),
+    ]
+    _render_stat_card_grid(cards)
+
+
+# ── Grid row builders ─────────────────────────────────────────────────────────
+
 def _build_order_rows(all_orders: list[dict]) -> tuple[list[dict], list[dict]]:
     sell_orders: list[dict] = []
     buy_orders: list[dict] = []
     for order in all_orders:
-        common_fields = {
+        # Core fields — Station/Region/Range deliberately excluded here, added last below
+        core = {
             "Owner": order.get("owner", ""),
             "Icon": get_item_image_url(order),
             "Type": order.get("type_name", ""),
@@ -47,21 +230,18 @@ def _build_order_rows(all_orders: list[dict]) -> tuple[list[dict], list[dict]]:
             "Volume": order.get("volume", 0),
             "Total Price": order.get("total_price", 0),
             "Expires In": order.get("expires_in", ""),
+        }
+        # Trailing location columns — always last
+        location = {
             "Station": order.get("station", ""),
             "Region": order.get("region", ""),
             "Range": order.get("range", ""),
         }
+
         if order.get("is_buy_order"):
-            buy_orders.append(
-                {
-                    **common_fields,
-                    "Min. Volume": order.get("min_volume", 0),
-                    "Escrow Remaining": order.get("escrow_remaining", 0),
-                }
-            )
+            buy_orders.append({**core, "Min. Volume": order.get("min_volume", 0), "Escrow Remaining": order.get("escrow_remaining", 0), **location})
         else:
-            sell_order = dict(common_fields)
-            # Add advised price if available
+            sell_order: dict = dict(core)
             if order.get("advised_price"):
                 sell_order["Advised Price"] = order.get("advised_price", 0)
                 sell_order["Advice Confidence"] = order.get("advised_price_confidence", "N/A")
@@ -73,9 +253,14 @@ def _build_order_rows(all_orders: list[dict]) -> tuple[list[dict], list[dict]]:
                 sell_order["Margin % (Current)"] = round(float(order["net_margin_pct_current"]), 1)
             if order.get("net_margin_pct_advised") is not None:
                 sell_order["Margin % (Advised)"] = round(float(order["net_margin_pct_advised"]), 1)
+            # Location always last
+            sell_order.update(location)
             sell_orders.append(sell_order)
+
     return sell_orders, buy_orders
 
+
+# ── Grid renderer ─────────────────────────────────────────────────────────────
 
 def _render_orders_grid(
     df: pd.DataFrame,
@@ -87,8 +272,8 @@ def _render_orders_grid(
     key: str,
 ) -> None:
     gb = runtime.grid_options_builder.from_dataframe(df)
-    gb.configure_default_column(resizable=True, sortable=True, filter=True)
-    gb.configure_column("Icon", headerName="", width=60, cellRenderer=img_renderer, suppressSizeToFit=True)
+    gb.configure_default_column(resizable=True, sortable=True, filter=True, minWidth=80)
+    gb.configure_column("Icon", headerName="", width=46, cellRenderer=img_renderer, suppressSizeToFit=True, resizable=False, sortable=False, filter=False)
 
     right = {"textAlign": "right"}
     for col in isk_cols:
@@ -98,11 +283,11 @@ def _render_orders_grid(
                 type=["numericColumn", "numberColumnFilter"],
                 valueFormatter=js_eu_isk_formatter(JsCode=runtime.js_code, locale=runtime.locale, decimals=2),
                 cellStyle=right,
-                minWidth=120,
+                minWidth=110,
             )
 
     if "Volume" in df.columns:
-        gb.configure_column("Volume", cellStyle=right, minWidth=110)
+        gb.configure_column("Volume", cellStyle=right, minWidth=90)
 
     if "Est. Days (Adv.)" in df.columns:
         gb.configure_column(
@@ -110,7 +295,7 @@ def _render_orders_grid(
             type=["numericColumn", "numberColumnFilter"],
             valueFormatter=js_eu_number_formatter(JsCode=runtime.js_code, locale=runtime.locale, decimals=1),
             cellStyle=right,
-            minWidth=110,
+            minWidth=100,
         )
 
     margin_style = js_margin_pct_cell_style(JsCode=runtime.js_code)
@@ -122,7 +307,7 @@ def _render_orders_grid(
                 type=["numericColumn", "numberColumnFilter"],
                 valueFormatter=margin_fmt,
                 cellStyle=margin_style,
-                minWidth=130,
+                minWidth=120,
             )
 
     if min_volume and "Min. Volume" in df.columns:
@@ -131,8 +316,28 @@ def _render_orders_grid(
             type=["numericColumn", "numberColumnFilter"],
             valueFormatter=js_eu_number_formatter(JsCode=runtime.js_code, locale=runtime.locale, decimals=0),
             cellStyle=right,
-            minWidth=110,
+            minWidth=90,
         )
+
+    # Cap location columns so they don't dominate the layout
+    for col, max_w in (("Station", 220), ("Region", 160), ("Range", 90)):
+        if col in df.columns:
+            gb.configure_column(col, minWidth=80, maxWidth=max_w)
+
+    # Auto-size all columns to their content on first render
+    auto_size = runtime.js_code(
+        """
+        function(e) {
+            var api = e.columnApi || (e.api && e.api.columnModel ? e.api : null);
+            if (api && api.autoSizeAllColumns) {
+                api.autoSizeAllColumns(false);
+            } else if (e.api && e.api.autoSizeAllColumns) {
+                e.api.autoSizeAllColumns(false);
+            }
+        }
+        """
+    )
+    gb.configure_grid_options(onFirstDataRendered=auto_size)
 
     runtime.aggrid_fn(
         df,
@@ -144,13 +349,13 @@ def _render_orders_grid(
     )
 
 
+# ── Pricing analysis panel ────────────────────────────────────────────────────
+
 def _render_pricing_analysis(selected_order: dict) -> None:
-    """Render the full pricing analysis panel for a single sell order."""
     if not selected_order.get("pricing_breakdown"):
         st.info("No pricing analysis available for this order yet.")
         return
 
-    # --- Row 1: Price / Confidence / Cost ---
     col1, col2, col3 = st.columns(3)
 
     with col1:
@@ -181,11 +386,8 @@ def _render_pricing_analysis(selected_order: dict) -> None:
                 source_label = "Built" if source == "manufactured" else "Bought" if source == "bought" else source.title()
 
             st.metric("Your Cost", format_isk_short(cost_basis))
-
             if cost_source == "market_order_fallback":
                 st.warning("No acquisition cost found — order price used as estimate. Margin figures are unreliable.")
-            elif cost_source == "asset_history":
-                st.caption(f"({source_label})")
             else:
                 st.caption(f"({source_label})")
 
@@ -195,7 +397,6 @@ def _render_pricing_analysis(selected_order: dict) -> None:
         else:
             st.caption("No cost data available")
 
-    # --- Row 2: Profitability metrics ---
     net_margin_adv = selected_order.get("net_margin_pct_advised")
     net_margin_cur = selected_order.get("net_margin_pct_current")
     est_days_adv = selected_order.get("estimated_sell_days_advised")
@@ -203,8 +404,7 @@ def _render_pricing_analysis(selected_order: dict) -> None:
     isk_day_adv = selected_order.get("isk_per_day_advised")
     isk_day_cur = selected_order.get("isk_per_day_current")
 
-    has_profitability = any(v is not None for v in [net_margin_adv, net_margin_cur, est_days_adv, isk_day_adv])
-    if has_profitability:
+    if any(v is not None for v in [net_margin_adv, net_margin_cur, est_days_adv, isk_day_adv]):
         st.write("**Profitability (after sales tax & broker fee):**")
         pm1, pm2, pm3 = st.columns(3)
 
@@ -233,7 +433,6 @@ def _render_pricing_analysis(selected_order: dict) -> None:
                 st.metric("ISK/day (Current)", format_isk_short(isk_day_cur),
                           delta=format_isk_short(delta) if delta is not None else None)
 
-    # --- Expiry urgency ---
     expiry_detail = selected_order.get("expiry_urgency_detail")
     if expiry_detail:
         st.warning(
@@ -242,7 +441,6 @@ def _render_pricing_analysis(selected_order: dict) -> None:
                f"urgency-adjusted: **{format_isk_short(expiry_detail.get('urgency_adjusted_price'))}**")
         )
 
-    # --- Hold signal ---
     hold_signal = selected_order.get("hold_signal")
     if hold_signal and hold_signal.get("suggested"):
         est_price_7d = hold_signal.get("estimated_price_7d")
@@ -253,7 +451,6 @@ def _render_pricing_analysis(selected_order: dict) -> None:
             + (f"  \nTotal extra gain if held: **{format_isk_short(total_gain)}**" if total_gain else "")
         )
 
-    # --- Relist risk ---
     relist_risk = selected_order.get("relist_risk")
     if relist_risk and relist_risk.get("at_risk"):
         relist_cost = relist_risk.get("estimated_relist_cost", 0)
@@ -263,21 +460,14 @@ def _render_pricing_analysis(selected_order: dict) -> None:
             + (f"  \nEst. {unsold_qty} units unsold at expiry — relist cost ~**{format_isk_short(relist_cost)}**" if relist_cost else "")
         )
 
-    # --- Pricing components breakdown ---
     st.write("**Pricing Components:**")
     breakdown = selected_order.get("pricing_breakdown", {})
     components = breakdown.get("components", {})
-
     for comp_name, comp_data in components.items():
         value = comp_data.get("value", 0)
         weight = comp_data.get("weight", 0) * 100
-
         friendly_name = comp_name.replace("_", " ").title()
-        st.write(
-            f"• {friendly_name}: {format_isk_short(value)} ({weight:.0f}% weight)",
-            unsafe_allow_html=True
-        )
-
+        st.write(f"• {friendly_name}: {format_isk_short(value)} ({weight:.0f}% weight)", unsafe_allow_html=True)
         if comp_name == "your_cost_basis" and comp_data.get("raw_cost"):
             source = selected_order.get("acquisition_source", "unknown")
             source_label = "Built" if source == "manufactured" else "Bought" if source == "bought" else source.title()
@@ -294,15 +484,14 @@ def _render_pricing_analysis(selected_order: dict) -> None:
         elif comp_name == "buy_sell_spread" and comp_data.get("spread_pct") is not None:
             st.caption(f"  {comp_data.get('label', '')}")
 
-    # --- Fill-rate velocity ---
     fill_rate = selected_order.get("fill_rate_velocity")
     if fill_rate:
         fr_conf = fill_rate.get("confidence", "low")
+        fr_txns = fill_rate.get("transaction_count", 0)
+        fr_days = fill_rate.get("day_span", 0)
         fr_raw = fill_rate.get("daily_velocity_raw", 0)
         fr_adj = fill_rate.get("daily_velocity_adjusted", 0)
         fr_median = fill_rate.get("median_historical_price", 0)
-        fr_txns = fill_rate.get("transaction_count", 0)
-        fr_days = fill_rate.get("day_span", 0)
         elastic = fill_rate.get("elasticity_factor", 1.0)
         st.write(f"**Historical Fill Rate** ({fr_conf} confidence — {fr_txns} sales over {fr_days}d):")
         st.caption(
@@ -311,7 +500,6 @@ def _render_pricing_analysis(selected_order: dict) -> None:
             f"Median historical sale price: {format_isk_short(fr_median)}"
         )
 
-    # --- Seller concentration ---
     conc = selected_order.get("seller_concentration")
     if conc and conc.get("risk_label"):
         sniper = conc.get("sniper_risk", False)
@@ -325,40 +513,30 @@ def _render_pricing_analysis(selected_order: dict) -> None:
                 f"{conc.get('note', '')}"
             )
 
-    # --- Price band ---
     price_band = selected_order.get("price_band")
     min_margin_pct = selected_order.get("min_target_margin_pct")
     if price_band:
         st.write(f"**Price Band** (min target margin: {min_margin_pct or 8:.1f}%):")
         pb_cols = st.columns(3)
-        tiers = [
-            ("aggressive", pb_cols[0]),
-            ("target", pb_cols[1]),
-            ("premium", pb_cols[2]),
-        ]
-        for tier_key, col in tiers:
+        for tier_key, col in [("aggressive", pb_cols[0]), ("target", pb_cols[1]), ("premium", pb_cols[2])]:
             tier = price_band.get(tier_key, {})
             if not tier:
                 continue
             with col:
-                tier_price = tier.get("price")
-                tier_label = tier.get("label", tier_key.title())
-                st.metric(tier_label, format_isk_short(tier_price) if tier_price else "—")
-                est_d = tier.get("estimated_sell_days")
-                isk_d = tier.get("isk_per_day")
-                margin = tier.get("net_margin_pct")
+                st.metric(tier.get("label", tier_key.title()), format_isk_short(tier.get("price")) if tier.get("price") else "—")
                 details = []
-                if est_d is not None:
-                    details.append(f"~{est_d:.1f}d to sell")
-                if isk_d is not None:
-                    details.append(f"{format_isk_short(isk_d)}/day")
-                if margin is not None:
-                    details.append(f"{margin:.1f}% margin")
+                if tier.get("estimated_sell_days") is not None:
+                    details.append(f"~{tier['estimated_sell_days']:.1f}d to sell")
+                if tier.get("isk_per_day") is not None:
+                    details.append(f"{format_isk_short(tier['isk_per_day'])}/day")
+                if tier.get("net_margin_pct") is not None:
+                    details.append(f"{tier['net_margin_pct']:.1f}% margin")
                 if details:
                     st.caption("  \n".join(details))
 
 
-# -- Main Render Function --
+# ── Main render ───────────────────────────────────────────────────────────────
+
 def render():
     st.header("Market Orders")
 
@@ -377,20 +555,14 @@ def render():
     sell_orders, buy_orders = _build_order_rows(all_orders)
 
     if sell_orders:
-        # Build DataFrame first
         df = pd.DataFrame(sell_orders)
-        df = df.reset_index(drop=True).sort_values(
-            by=["Type", "Price"], ascending=[True, True]
-        )
+        df = df.reset_index(drop=True).sort_values(by=["Type", "Price"], ascending=[True, True])
 
-        # Filters
-        owner, refresh_col, filler = st.columns([1, 2, 3])
-
-        with owner:
+        # Owner filter + refresh button
+        owner_col, refresh_col, filler = st.columns([1, 2, 3])
+        with owner_col:
             owners = ["All"] + sorted(df["Owner"].unique())
-            selected_owner = st.selectbox(
-                "Filter by Owner", owners, index=0, label_visibility="hidden"
-            )
+            selected_owner = st.selectbox("Filter by Owner", owners, index=0, label_visibility="hidden")
             if selected_owner != "All":
                 df = df[df["Owner"] == selected_owner]
         with refresh_col:
@@ -408,7 +580,7 @@ def render():
 
         st.subheader("Selling")
 
-        # Negative-margin warning — items where current price results in a loss after fees
+        # Negative-margin warning
         if "Margin % (Current)" in df.columns:
             loss_rows = df[df["Margin % (Current)"] < 0]
             if not loss_rows.empty:
@@ -418,13 +590,14 @@ def render():
                     f"{loss_names}. Consider relisting at or above the Advised Price."
                 )
 
-        # Overview
-        st.write(
-            "Active Orders: <strong>{}</strong>&nbsp;&nbsp;Total ISK: <strong>{}</strong>".format(
-                len(df), format_isk_short(df["Total Price"].sum())
-            ),
-            unsafe_allow_html=True,
-        )
+        # Stats box — computed from the filtered raw enriched orders
+        sell_raw_filtered = [
+            o for o in all_orders
+            if not o.get("is_buy_order") and (selected_owner == "All" or o.get("owner") == selected_owner)
+        ]
+        stats = _compute_sell_stats(sell_raw_filtered)
+        _render_sell_stats_box(stats)
+        st.write("")  # spacing below stat box
 
         isk_cols = ["Price", "Total Price", "Price Difference"]
         if "Advised Price" in df.columns:
@@ -432,50 +605,25 @@ def render():
         if "ISK/day (Adv.)" in df.columns:
             isk_cols.append("ISK/day (Adv.)")
 
-        _render_orders_grid(
-            df,
-            runtime=runtime,
-            img_renderer=img_renderer,
-            isk_cols=isk_cols,
-            min_volume=False,
-            key="market_orders_sell",
-        )
+        _render_orders_grid(df, runtime=runtime, img_renderer=img_renderer, isk_cols=isk_cols, min_volume=False, key="market_orders_sell")
     else:
         st.info("No market sell orders found.")
 
     if buy_orders:
         st.subheader("Buying")
-        df = pd.DataFrame(buy_orders)
-        df = df.reset_index(drop=True).sort_values(
-            by=["Type", "Price"], ascending=[True, False]
-        )
-
-        # Filters
+        df_buy = pd.DataFrame(buy_orders)
+        df_buy = df_buy.reset_index(drop=True).sort_values(by=["Type", "Price"], ascending=[True, False])
         if selected_owner != "All":
-            df = df[df["Owner"] == selected_owner]
+            df_buy = df_buy[df_buy["Owner"] == selected_owner]
 
-        # Overview
-        st.write(
-            "Active Orders: <strong>{}</strong>&nbsp;&nbsp;Total ISK: <strong>{}</strong>&nbsp;&nbsp;Total Escrow: <strong>{}</strong>".format(
-                len(df),
-                format_isk_short(df["Total Price"].sum()),
-                format_isk_short(df["Escrow Remaining"].sum()),
-            ),
-            unsafe_allow_html=True,
-        )
+        _render_buy_stats_box(df_buy)
+        st.write("")
 
-        _render_orders_grid(
-            df,
-            runtime=runtime,
-            img_renderer=img_renderer,
-            isk_cols=["Price", "Total Price", "Price Difference", "Escrow Remaining"],
-            min_volume=True,
-            key="market_orders_buy",
-        )
+        _render_orders_grid(df_buy, runtime=runtime, img_renderer=img_renderer, isk_cols=["Price", "Total Price", "Price Difference", "Escrow Remaining"], min_volume=True, key="market_orders_buy")
     else:
         st.info("No market buy orders found.")
 
-    # Repricing priority queue — sell orders ranked by urgency
+    # Repricing priority queue
     if sell_orders:
         priority_orders = sorted(
             [o for o in all_orders if not o.get("is_buy_order") and o.get("reprice_priority_score", 0) > 0],
@@ -502,7 +650,10 @@ def render():
                     detail = o.get("expiry_urgency_detail") or {}
                     days_rem = detail.get("days_remaining")
                     est_sell = detail.get("est_days_advised")
-                    flags.append(f"⏰ expires in {days_rem}d (est. {est_sell:.0f}d to sell)" if days_rem is not None and est_sell is not None else "⏰ expiry urgency")
+                    flags.append(
+                        f"⏰ expires in {days_rem}d (est. {est_sell:.0f}d to sell)"
+                        if days_rem is not None and est_sell is not None else "⏰ expiry urgency"
+                    )
                 if (o.get("relist_risk") or {}).get("at_risk"):
                     flags.append("🔁 relist risk")
                 if adv < cur:
@@ -515,8 +666,7 @@ def render():
 
                 flag_str = "  ·  ".join(flags) if flags else ""
                 st.write(
-                    f"**#{rank}** &nbsp; {name} &nbsp; "
-                    f"(score: {score:.0f}) &nbsp; "
+                    f"**#{rank}** &nbsp; {name} &nbsp; (score: {score:.0f}) &nbsp; "
                     f"{format_isk_short(cur)} → **{format_isk_short(adv)}**"
                     + (f"  ·  margin: {margin_cur:.1f}%" if margin_cur is not None else ""),
                     unsafe_allow_html=True,
@@ -524,24 +674,19 @@ def render():
                 if flag_str or isk_gain:
                     st.caption(f"{flag_str}{isk_gain}")
 
-    # Details section for pricing analysis (sell orders)
+    # Pricing analysis panel
     if sell_orders:
         st.divider()
         st.subheader("📊 Pricing Analysis")
-
-        # Rebuild full dataframe with order data for selection
         full_sell_orders = [o for o in all_orders if not o.get("is_buy_order")]
-
         if full_sell_orders:
             order_options = [
                 f"{o.get('type_name', 'Unknown')} @ {o.get('station', 'Unknown')} - {format_isk_short(o.get('price', 0))}/unit"
                 for o in full_sell_orders
             ]
-
             selected_idx = st.selectbox(
                 "Select order to view detailed pricing analysis",
                 range(len(order_options)),
                 format_func=lambda i: order_options[i],
             )
-
             _render_pricing_analysis(full_sell_orders[selected_idx])

--- a/src/streamlit_ui/pages/marketorders.py
+++ b/src/streamlit_ui/pages/marketorders.py
@@ -233,6 +233,15 @@ def _render_pricing_analysis(selected_order: dict) -> None:
                 st.metric("ISK/day (Current)", format_isk_short(isk_day_cur),
                           delta=format_isk_short(delta) if delta is not None else None)
 
+    # --- Expiry urgency ---
+    expiry_detail = selected_order.get("expiry_urgency_detail")
+    if expiry_detail:
+        st.warning(
+            f"**Expiry urgency:** {expiry_detail.get('reason', '')}"
+            + (f"  \nOriginal advised: **{format_isk_short(expiry_detail.get('original_advised'))}** → "
+               f"urgency-adjusted: **{format_isk_short(expiry_detail.get('urgency_adjusted_price'))}**")
+        )
+
     # --- Hold signal ---
     hold_signal = selected_order.get("hold_signal")
     if hold_signal and hold_signal.get("suggested"):
@@ -284,6 +293,37 @@ def _render_pricing_analysis(selected_order: dict) -> None:
             st.caption(f"  {comp_data.get('label', '')}")
         elif comp_name == "buy_sell_spread" and comp_data.get("spread_pct") is not None:
             st.caption(f"  {comp_data.get('label', '')}")
+
+    # --- Fill-rate velocity ---
+    fill_rate = selected_order.get("fill_rate_velocity")
+    if fill_rate:
+        fr_conf = fill_rate.get("confidence", "low")
+        fr_raw = fill_rate.get("daily_velocity_raw", 0)
+        fr_adj = fill_rate.get("daily_velocity_adjusted", 0)
+        fr_median = fill_rate.get("median_historical_price", 0)
+        fr_txns = fill_rate.get("transaction_count", 0)
+        fr_days = fill_rate.get("day_span", 0)
+        elastic = fill_rate.get("elasticity_factor", 1.0)
+        st.write(f"**Historical Fill Rate** ({fr_conf} confidence — {fr_txns} sales over {fr_days}d):")
+        st.caption(
+            f"Raw velocity: {fr_raw:.2f} units/day  |  "
+            f"Adjusted (elasticity {elastic:.2f}×): {fr_adj:.2f} units/day  |  "
+            f"Median historical sale price: {format_isk_short(fr_median)}"
+        )
+
+    # --- Seller concentration ---
+    conc = selected_order.get("seller_concentration")
+    if conc and conc.get("risk_label"):
+        sniper = conc.get("sniper_risk", False)
+        icon = "🔴" if sniper else ("🟡" if conc.get("front_2_volume_pct", 0) > 60 else "🟢")
+        st.write(f"**Queue Concentration:** {icon} {conc.get('risk_label', '')}")
+        if conc.get("note"):
+            st.caption(
+                f"Top level: {conc.get('front_1_volume_pct', 0):.0f}% of visible volume  |  "
+                f"Top 2 levels: {conc.get('front_2_volume_pct', 0):.0f}%  |  "
+                f"{conc.get('num_price_levels', 0)} price levels  |  "
+                f"{conc.get('note', '')}"
+            )
 
     # --- Price band ---
     price_band = selected_order.get("price_band")
@@ -434,6 +474,55 @@ def render():
         )
     else:
         st.info("No market buy orders found.")
+
+    # Repricing priority queue — sell orders ranked by urgency
+    if sell_orders:
+        priority_orders = sorted(
+            [o for o in all_orders if not o.get("is_buy_order") and o.get("reprice_priority_score", 0) > 0],
+            key=lambda o: o.get("reprice_priority_score", 0),
+            reverse=True,
+        )
+        if priority_orders:
+            st.divider()
+            st.subheader("🔧 Repricing Priority Queue")
+            st.caption("Orders ranked by urgency — fix these first.")
+            for rank, o in enumerate(priority_orders[:10], start=1):
+                score = o.get("reprice_priority_score", 0)
+                name = o.get("type_name", "Unknown")
+                cur = float(o.get("price") or 0)
+                adv = float(o.get("advised_price") or cur)
+                margin_cur = o.get("net_margin_pct_current")
+                isk_adv = o.get("isk_per_day_advised")
+                isk_cur = o.get("isk_per_day_current")
+
+                flags = []
+                if (margin_cur or 0) < 0:
+                    flags.append("❌ below break-even")
+                if o.get("expiry_urgency"):
+                    detail = o.get("expiry_urgency_detail") or {}
+                    days_rem = detail.get("days_remaining")
+                    est_sell = detail.get("est_days_advised")
+                    flags.append(f"⏰ expires in {days_rem}d (est. {est_sell:.0f}d to sell)" if days_rem is not None and est_sell is not None else "⏰ expiry urgency")
+                if (o.get("relist_risk") or {}).get("at_risk"):
+                    flags.append("🔁 relist risk")
+                if adv < cur:
+                    diff_pct = (cur - adv) / cur * 100
+                    flags.append(f"📉 {diff_pct:.1f}% above advised")
+
+                isk_gain = ""
+                if isk_adv and isk_cur and isk_adv > isk_cur:
+                    isk_gain = f"  ·  +{format_isk_short(isk_adv - isk_cur)}/day if repriced"
+
+                flag_str = "  ·  ".join(flags) if flags else ""
+                st.write(
+                    f"**#{rank}** &nbsp; {name} &nbsp; "
+                    f"(score: {score:.0f}) &nbsp; "
+                    f"{format_isk_short(cur)} → **{format_isk_short(adv)}**"
+                    + (f"  ·  margin: {margin_cur:.1f}%" if margin_cur is not None else ""),
+                    unsafe_allow_html=True,
+                )
+                if flag_str or isk_gain:
+                    st.caption(f"{flag_str}{isk_gain}")
 
     # Details section for pricing analysis (sell orders)
     if sell_orders:

--- a/src/streamlit_ui/pages/marketorders.py
+++ b/src/streamlit_ui/pages/marketorders.py
@@ -65,6 +65,10 @@ def _build_order_rows(all_orders: list[dict]) -> tuple[list[dict], list[dict]]:
             if order.get("advised_price"):
                 sell_order["Advised Price"] = order.get("advised_price", 0)
                 sell_order["Advice Confidence"] = order.get("advised_price_confidence", "N/A")
+            if order.get("estimated_sell_days_advised") is not None:
+                sell_order["Est. Days (Adv.)"] = round(float(order["estimated_sell_days_advised"]), 1)
+            if order.get("isk_per_day_advised") is not None:
+                sell_order["ISK/day (Adv.)"] = order["isk_per_day_advised"]
             sell_orders.append(sell_order)
     return sell_orders, buy_orders
 
@@ -96,6 +100,15 @@ def _render_orders_grid(
     if "Volume" in df.columns:
         gb.configure_column("Volume", cellStyle=right, minWidth=110)
 
+    if "Est. Days (Adv.)" in df.columns:
+        gb.configure_column(
+            "Est. Days (Adv.)",
+            type=["numericColumn", "numberColumnFilter"],
+            valueFormatter=js_eu_number_formatter(JsCode=runtime.js_code, locale=runtime.locale, decimals=1),
+            cellStyle=right,
+            minWidth=110,
+        )
+
     if min_volume and "Min. Volume" in df.columns:
         gb.configure_column(
             "Min. Volume",
@@ -115,6 +128,137 @@ def _render_orders_grid(
     )
 
 
+def _render_pricing_analysis(selected_order: dict) -> None:
+    """Render the full pricing analysis panel for a single sell order."""
+    if not selected_order.get("pricing_breakdown"):
+        st.info("No pricing analysis available for this order yet.")
+        return
+
+    # --- Row 1: Price / Confidence / Cost ---
+    col1, col2, col3 = st.columns(3)
+
+    with col1:
+        st.metric("Current Price", format_isk_short(selected_order.get("price", 0)))
+        if selected_order.get("advised_price"):
+            advised = selected_order.get("advised_price", 0)
+            st.metric("Advised Price", format_isk_short(advised))
+            diff = advised - selected_order.get("price", 0)
+            diff_pct = selected_order.get("price_difference_pct") or 0
+            st.metric("Difference", format_isk_short(diff), f"{diff_pct:+.1f}%")
+
+    with col2:
+        st.metric("Confidence", selected_order.get("advised_price_confidence", "N/A"))
+        st.caption(selected_order.get("pricing_reasoning", ""))
+
+    with col3:
+        if selected_order.get("cost_basis"):
+            cost_basis = selected_order.get("cost_basis", 0)
+            source = selected_order.get("acquisition_source", "unknown")
+            cost_source = selected_order.get("cost_basis_source", "asset")
+
+            if cost_source == "market_order_fallback":
+                source_label = "Order Price (ESI Data Issue)"
+            else:
+                source_label = "Built" if source == "manufactured" else "Bought" if source == "bought" else source.title()
+
+            st.metric("Your Cost", format_isk_short(cost_basis))
+
+            if cost_source == "market_order_fallback":
+                st.warning("⚠️ Asset missing from inventory. Using order price as cost estimate.")
+            else:
+                st.caption(f"({source_label})")
+
+            break_even = selected_order.get("break_even_price")
+            if break_even:
+                st.metric("Break-even Price", format_isk_short(break_even))
+        else:
+            st.caption("No cost data available")
+
+    # --- Row 2: Profitability metrics ---
+    net_margin_adv = selected_order.get("net_margin_pct_advised")
+    net_margin_cur = selected_order.get("net_margin_pct_current")
+    est_days_adv = selected_order.get("estimated_sell_days_advised")
+    est_days_cur = selected_order.get("estimated_sell_days_current")
+    isk_day_adv = selected_order.get("isk_per_day_advised")
+    isk_day_cur = selected_order.get("isk_per_day_current")
+
+    has_profitability = any(v is not None for v in [net_margin_adv, net_margin_cur, est_days_adv, isk_day_adv])
+    if has_profitability:
+        st.write("**Profitability (after sales tax & broker fee):**")
+        pm1, pm2, pm3 = st.columns(3)
+
+        with pm1:
+            if net_margin_adv is not None:
+                st.metric("Net Margin (Advised)", f"{net_margin_adv:.1f}%")
+            if net_margin_cur is not None:
+                delta = (net_margin_adv - net_margin_cur) if net_margin_adv is not None else None
+                st.metric("Net Margin (Current)", f"{net_margin_cur:.1f}%",
+                          delta=f"{delta:+.1f}pp" if delta is not None else None)
+
+        with pm2:
+            if est_days_adv is not None:
+                st.metric("Est. Days to Sell (Advised)", f"{est_days_adv:.1f}d")
+            if est_days_cur is not None:
+                delta = (est_days_adv - est_days_cur) if est_days_adv is not None else None
+                st.metric("Est. Days to Sell (Current)", f"{est_days_cur:.1f}d",
+                          delta=f"{delta:+.1f}d" if delta is not None else None,
+                          delta_color="inverse")
+
+        with pm3:
+            if isk_day_adv is not None:
+                st.metric("ISK/day (Advised)", format_isk_short(isk_day_adv))
+            if isk_day_cur is not None:
+                delta = (isk_day_adv - isk_day_cur) if isk_day_adv is not None else None
+                st.metric("ISK/day (Current)", format_isk_short(isk_day_cur),
+                          delta=format_isk_short(delta) if delta is not None else None)
+
+    # --- Hold signal ---
+    hold_signal = selected_order.get("hold_signal")
+    if hold_signal and hold_signal.get("suggested"):
+        est_price_7d = hold_signal.get("estimated_price_7d")
+        total_gain = hold_signal.get("estimated_gain_total", 0)
+        st.info(
+            f"**Hold suggestion:** {hold_signal.get('reason', '')}"
+            + (f"  \nEstimated price in 7 days: **{format_isk_short(est_price_7d)}**" if est_price_7d else "")
+            + (f"  \nTotal extra gain if held: **{format_isk_short(total_gain)}**" if total_gain else "")
+        )
+
+    # --- Relist risk ---
+    relist_risk = selected_order.get("relist_risk")
+    if relist_risk and relist_risk.get("at_risk"):
+        relist_cost = relist_risk.get("estimated_relist_cost", 0)
+        unsold_qty = relist_risk.get("estimated_unsold_quantity", 0)
+        st.warning(
+            f"**Relist risk:** {relist_risk.get('reason', '')}"
+            + (f"  \nEst. {unsold_qty} units unsold at expiry — relist cost ~**{format_isk_short(relist_cost)}**" if relist_cost else "")
+        )
+
+    # --- Pricing components breakdown ---
+    st.write("**Pricing Components:**")
+    breakdown = selected_order.get("pricing_breakdown", {})
+    components = breakdown.get("components", {})
+
+    for comp_name, comp_data in components.items():
+        value = comp_data.get("value", 0)
+        weight = comp_data.get("weight", 0) * 100
+
+        friendly_name = comp_name.replace("_", " ").title()
+        st.write(
+            f"• {friendly_name}: {format_isk_short(value)} ({weight:.0f}% weight)",
+            unsafe_allow_html=True
+        )
+
+        if comp_name == "your_cost_basis" and comp_data.get("raw_cost"):
+            source = selected_order.get("acquisition_source", "unknown")
+            source_label = "Built" if source == "manufactured" else "Bought" if source == "bought" else source.title()
+            margin = comp_data.get("margin_pct", 5)
+            st.caption(f"  Raw cost: {format_isk_short(comp_data['raw_cost'])}, with {margin}% margin ({source_label})")
+        elif comp_name == "your_recent_sales" and comp_data.get("sample_size"):
+            st.caption(f"  Based on {comp_data['sample_size']} recent sales ({comp_data.get('confidence', 'N/A')} confidence)")
+        elif comp_name == "market_trend" and comp_data.get("trend_pct"):
+            st.caption(f"  42w avg: {format_isk_short(comp_data.get('avg_42w', 0))}, 7d avg: {format_isk_short(comp_data.get('avg_7d', 0))}, trend: {comp_data['trend_pct']:+.1f}%")
+
+
 # -- Main Render Function --
 def render():
     st.header("Market Orders")
@@ -132,7 +276,7 @@ def render():
 
     selected_owner = "All"
     sell_orders, buy_orders = _build_order_rows(all_orders)
-    
+
     if sell_orders:
         # Build DataFrame first
         df = pd.DataFrame(sell_orders)
@@ -141,7 +285,7 @@ def render():
         )
 
         # Filters
-        owner, refresh_market_orders, filler = st.columns([1, 2, 3])
+        owner, refresh_col, filler = st.columns([1, 2, 3])
 
         with owner:
             owners = ["All"] + sorted(df["Owner"].unique())
@@ -150,7 +294,7 @@ def render():
             )
             if selected_owner != "All":
                 df = df[df["Owner"] == selected_owner]
-        with refresh_market_orders:
+        with refresh_col:
             st.write("<br>", unsafe_allow_html=True)
             if st.button("Refresh Market Orders"):
                 with st.spinner("Refreshing market orders..."):
@@ -176,6 +320,8 @@ def render():
         isk_cols = ["Price", "Total Price", "Price Difference"]
         if "Advised Price" in df.columns:
             isk_cols.append("Advised Price")
+        if "ISK/day (Adv.)" in df.columns:
+            isk_cols.append("ISK/day (Adv.)")
 
         _render_orders_grid(
             df,
@@ -226,10 +372,7 @@ def render():
         st.subheader("📊 Pricing Analysis")
 
         # Rebuild full dataframe with order data for selection
-        full_sell_orders = []
-        for order in all_orders:
-            if not order.get("is_buy_order"):
-                full_sell_orders.append(order)
+        full_sell_orders = [o for o in all_orders if not o.get("is_buy_order")]
 
         if full_sell_orders:
             order_options = [
@@ -243,68 +386,4 @@ def render():
                 format_func=lambda i: order_options[i],
             )
 
-            selected_order = full_sell_orders[selected_idx]
-
-            if selected_order.get("pricing_breakdown"):
-                col1, col2, col3 = st.columns(3)
-
-                with col1:
-                    st.metric("Current Price", format_isk_short(selected_order.get("price", 0)))
-                    if selected_order.get("advised_price"):
-                        advised = selected_order.get("advised_price", 0)
-                        st.metric("Advised Price", format_isk_short(advised))
-                        diff = advised - selected_order.get("price", 0)
-                        diff_pct = selected_order.get("price_difference_pct", 0)
-                        st.metric("Difference", format_isk_short(diff), f"{diff_pct:+.1f}%")
-
-                with col2:
-                    st.metric("Confidence", selected_order.get("advised_price_confidence", "N/A"))
-                    st.caption(selected_order.get("pricing_reasoning", ""))
-
-                with col3:
-                    if selected_order.get("cost_basis"):
-                        cost_basis = selected_order.get("cost_basis", 0)
-                        source = selected_order.get("acquisition_source", "unknown")
-                        cost_source = selected_order.get("cost_basis_source", "asset")
-
-                        if cost_source == "market_order_fallback":
-                            source_label = "Order Price (ESI Data Issue)"
-                        else:
-                            source_label = "Built" if source == "manufactured" else "Bought" if source == "bought" else source.title()
-
-                        st.metric("Your Cost", format_isk_short(cost_basis))
-
-                        if cost_source == "market_order_fallback":
-                            st.warning("⚠️ Asset missing from inventory. Using order price as cost estimate.")
-                        else:
-                            st.caption(f"({source_label})")
-                    else:
-                        st.caption("No cost data available")
-
-                # Show breakdown components
-                st.write("**Pricing Components:**")
-                breakdown = selected_order.get("pricing_breakdown", {})
-                components = breakdown.get("components", {})
-
-                for comp_name, comp_data in components.items():
-                    value = comp_data.get("value", 0)
-                    weight = comp_data.get("weight", 0) * 100
-
-                    friendly_name = comp_name.replace("_", " ").title()
-                    st.write(
-                        f"• {friendly_name}: {format_isk_short(value)} ({weight:.0f}% weight)",
-                        unsafe_allow_html=True
-                    )
-
-                    if comp_name == "your_cost_basis" and comp_data.get("raw_cost"):
-                        source = selected_order.get("acquisition_source", "unknown")
-                        source_label = "Built" if source == "manufactured" else "Bought" if source == "bought" else source.title()
-                        margin = comp_data.get("margin_pct", 5)
-                        st.caption(f"  Raw cost: {format_isk_short(comp_data['raw_cost'])}, with {margin}% margin ({source_label})")
-                    elif comp_name == "your_recent_sales" and comp_data.get("sample_size"):
-                        st.caption(f"  Based on {comp_data['sample_size']} recent sales ({comp_data.get('confidence', 'N/A')} confidence)")
-                    elif comp_name == "market_trend" and comp_data.get("trend_pct"):
-                        st.caption(f"  42w avg: {format_isk_short(comp_data.get('avg_42w', 0))}, 7d avg: {format_isk_short(comp_data.get('avg_7d', 0))}, trend: {comp_data['trend_pct']:+.1f}%")
-            else:
-                st.info("No pricing analysis available for this order yet.")
-
+            _render_pricing_analysis(full_sell_orders[selected_idx])

--- a/src/streamlit_ui/pages/marketorders.py
+++ b/src/streamlit_ui/pages/marketorders.py
@@ -278,6 +278,8 @@ def _render_orders_grid(
     gb = runtime.grid_options_builder.from_dataframe(df)
     gb.configure_default_column(resizable=True, sortable=True, filter=True, minWidth=80)
     gb.configure_column("Icon", headerName="", width=46, cellRenderer=img_renderer, suppressSizeToFit=True, resizable=False, sortable=False, filter=False)
+    if "Type" in df.columns:
+        gb.configure_column("Type", minWidth=140)
 
     right = {"textAlign": "right"}
     for col in isk_cols:
@@ -287,7 +289,7 @@ def _render_orders_grid(
                 type=["numericColumn", "numberColumnFilter"],
                 valueFormatter=js_eu_isk_formatter(JsCode=runtime.js_code, locale=runtime.locale, decimals=2),
                 cellStyle=right,
-                minWidth=110,
+                minWidth=160,
             )
 
     if "Volume" in df.columns:
@@ -342,16 +344,20 @@ def _render_orders_grid(
         if col in df.columns:
             gb.configure_column(col, minWidth=80, maxWidth=max_w)
 
-    # Auto-size all columns to their content on first render
+    # Auto-size all columns to content. Deferred 150ms so cells have painted first.
+    # AG Grid >= 31 merged columnApi into api; fall back to columnApi for older builds.
     auto_size = runtime.js_code(
         """
         function(e) {
-            var api = e.columnApi || (e.api && e.api.columnModel ? e.api : null);
-            if (api && api.autoSizeAllColumns) {
-                api.autoSizeAllColumns(false);
-            } else if (e.api && e.api.autoSizeAllColumns) {
-                e.api.autoSizeAllColumns(false);
-            }
+            var gridApi = e.api;
+            var colApi  = e.columnApi;
+            setTimeout(function() {
+                if (gridApi && typeof gridApi.autoSizeAllColumns === 'function') {
+                    gridApi.autoSizeAllColumns(false);
+                } else if (colApi && typeof colApi.autoSizeAllColumns === 'function') {
+                    colApi.autoSizeAllColumns(false);
+                }
+            }, 150);
         }
         """
     )

--- a/src/streamlit_ui/pages/marketorders.py
+++ b/src/streamlit_ui/pages/marketorders.py
@@ -278,6 +278,44 @@ def _render_pricing_analysis(selected_order: dict) -> None:
             st.caption(f"  Based on {comp_data['sample_size']} recent sales ({comp_data.get('confidence', 'N/A')} confidence)")
         elif comp_name == "market_trend" and comp_data.get("trend_pct"):
             st.caption(f"  42w avg: {format_isk_short(comp_data.get('avg_42w', 0))}, 7d avg: {format_isk_short(comp_data.get('avg_7d', 0))}, trend: {comp_data['trend_pct']:+.1f}%")
+        elif comp_name == "market_hub_price" and comp_data.get("volatility_dampened"):
+            st.caption(f"  Volatility-dampened (vol={comp_data.get('volatility_pct', 0):.1f}%) — hub weight reduced to {weight:.0f}%")
+        elif comp_name == "supply_demand" and comp_data.get("days_of_supply") is not None:
+            st.caption(f"  {comp_data.get('label', '')}")
+        elif comp_name == "buy_sell_spread" and comp_data.get("spread_pct") is not None:
+            st.caption(f"  {comp_data.get('label', '')}")
+
+    # --- Price band ---
+    price_band = selected_order.get("price_band")
+    min_margin_pct = selected_order.get("min_target_margin_pct")
+    if price_band:
+        st.write(f"**Price Band** (min target margin: {min_margin_pct or 8:.1f}%):")
+        pb_cols = st.columns(3)
+        tiers = [
+            ("aggressive", pb_cols[0]),
+            ("target", pb_cols[1]),
+            ("premium", pb_cols[2]),
+        ]
+        for tier_key, col in tiers:
+            tier = price_band.get(tier_key, {})
+            if not tier:
+                continue
+            with col:
+                tier_price = tier.get("price")
+                tier_label = tier.get("label", tier_key.title())
+                st.metric(tier_label, format_isk_short(tier_price) if tier_price else "—")
+                est_d = tier.get("estimated_sell_days")
+                isk_d = tier.get("isk_per_day")
+                margin = tier.get("net_margin_pct")
+                details = []
+                if est_d is not None:
+                    details.append(f"~{est_d:.1f}d to sell")
+                if isk_d is not None:
+                    details.append(f"{format_isk_short(isk_d)}/day")
+                if margin is not None:
+                    details.append(f"{margin:.1f}% margin")
+                if details:
+                    st.caption("  \n".join(details))
 
 
 # -- Main Render Function --

--- a/src/streamlit_ui/pages/marketorders.py
+++ b/src/streamlit_ui/pages/marketorders.py
@@ -157,14 +157,19 @@ def _render_pricing_analysis(selected_order: dict) -> None:
             cost_source = selected_order.get("cost_basis_source", "asset")
 
             if cost_source == "market_order_fallback":
-                source_label = "Order Price (ESI Data Issue)"
+                source_label = "Order Price (no cost record found)"
+            elif cost_source == "asset_history":
+                base = "Built" if source == "manufactured" else "Bought" if source == "bought" else source.title()
+                source_label = f"{base} (from history)"
             else:
                 source_label = "Built" if source == "manufactured" else "Bought" if source == "bought" else source.title()
 
             st.metric("Your Cost", format_isk_short(cost_basis))
 
             if cost_source == "market_order_fallback":
-                st.warning("⚠️ Asset missing from inventory. Using order price as cost estimate.")
+                st.warning("No acquisition cost found — order price used as estimate. Margin figures are unreliable.")
+            elif cost_source == "asset_history":
+                st.caption(f"({source_label})")
             else:
                 st.caption(f"({source_label})")
 

--- a/src/streamlit_ui/pages/marketorders.py
+++ b/src/streamlit_ui/pages/marketorders.py
@@ -1,7 +1,7 @@
 import streamlit as st # pyright: ignore[reportMissingImports]
 import pandas as pd # pyright: ignore[reportMissingModuleSource, reportMissingImports]
 
-from streamlit_ui.components.aggrid_formatters import js_eu_isk_formatter, js_eu_number_formatter, js_icon_cell_renderer
+from streamlit_ui.components.aggrid_formatters import js_eu_isk_formatter, js_eu_number_formatter, js_eu_pct_formatter, js_icon_cell_renderer, js_margin_pct_cell_style
 from streamlit_ui.components.assets_data import get_item_image_url as build_item_image_url
 from streamlit_ui.components.formatters import format_isk_short
 from streamlit_ui.api.market_orders import clear_market_orders_cache, fetch_market_orders, refresh_market_orders
@@ -69,6 +69,10 @@ def _build_order_rows(all_orders: list[dict]) -> tuple[list[dict], list[dict]]:
                 sell_order["Est. Days (Adv.)"] = round(float(order["estimated_sell_days_advised"]), 1)
             if order.get("isk_per_day_advised") is not None:
                 sell_order["ISK/day (Adv.)"] = order["isk_per_day_advised"]
+            if order.get("net_margin_pct_current") is not None:
+                sell_order["Margin % (Current)"] = round(float(order["net_margin_pct_current"]), 1)
+            if order.get("net_margin_pct_advised") is not None:
+                sell_order["Margin % (Advised)"] = round(float(order["net_margin_pct_advised"]), 1)
             sell_orders.append(sell_order)
     return sell_orders, buy_orders
 
@@ -108,6 +112,18 @@ def _render_orders_grid(
             cellStyle=right,
             minWidth=110,
         )
+
+    margin_style = js_margin_pct_cell_style(JsCode=runtime.js_code)
+    margin_fmt = js_eu_pct_formatter(JsCode=runtime.js_code, locale=runtime.locale, decimals=1)
+    for col in ("Margin % (Current)", "Margin % (Advised)"):
+        if col in df.columns:
+            gb.configure_column(
+                col,
+                type=["numericColumn", "numberColumnFilter"],
+                valueFormatter=margin_fmt,
+                cellStyle=margin_style,
+                minWidth=130,
+            )
 
     if min_volume and "Min. Volume" in df.columns:
         gb.configure_column(
@@ -313,6 +329,16 @@ def render():
             st.write("")
 
         st.subheader("Selling")
+
+        # Negative-margin warning — items where current price results in a loss after fees
+        if "Margin % (Current)" in df.columns:
+            loss_rows = df[df["Margin % (Current)"] < 0]
+            if not loss_rows.empty:
+                loss_names = ", ".join(loss_rows["Type"].tolist())
+                st.error(
+                    f"**{len(loss_rows)} order(s) are currently priced below break-even** (loss after fees): "
+                    f"{loss_names}. Consider relisting at or above the Advised Price."
+                )
 
         # Overview
         st.write(


### PR DESCRIPTION
## Summary

- **EVE price tick snapping** — all advised prices are aligned to EVE's 4-significant-figure tick constraint (`_eve_price_tick` / `_snap_to_eve_tick`), preventing invalid order modifications
- **Gap positioning** — `_find_gap_position` places orders 1 tick below the nearest undercutter rather than racing to the cheapest price in the book
- **Front-of-queue guard** — suppresses price reductions when already the cheapest seller (no margin benefit when there is no cheaper competitor)
- **Expiry urgency blending** — price blends toward aggressive tier proportionally as order expiry approaches
- **Fill-rate velocity and seller concentration signals** — surface market microstructure in the pricing breakdown
- **Outlier filtering** — removes statistical outliers from orderbook levels before computing weighted average
- **MarketPricingService injection** — constructed in `__init__` instead of looked up off state at call time, removing a fragile `getattr` pattern
- **Market orders grid** — stats box, column reorder, auto-size columns deferred 150ms for AG Grid >= 31 compatibility, Type column min-width, ISK columns widened

## Test plan

- [ ] Open market orders page and verify the grid renders with correct column widths and auto-sizes on load
- [ ] Select an order that is being undercut and confirm the advisory suggests a gap position (1 tick below nearest undercutter) rather than the absolute cheapest price
- [ ] Select an order where you are already the cheapest seller and confirm the advisory holds the current price
- [ ] Verify advised prices end in valid EVE tick increments for a range of price magnitudes (e.g. 1.5M ISK → nearest 1,000 ISK tick)
- [ ] Select an order close to expiry and confirm the urgency adjustment blends toward the aggressive tier